### PR TITLE
perf: pool the Supabase httpx client across requests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,6 +126,7 @@ See [docs/SECURITY.md](docs/SECURITY.md) for full security documentation.
 - B2 data access (repo layer): `services/api/app/repo/b2_client.py`
 - Pydantic models: `services/api/app/types/` (`files.py`, `upload.py`, `stats.py`, `formatting.py`)
 - Billing (layered): `services/api/app/runtime/billing.py` → `service/billing.py` → `repo/{stripe_client,supabase_billing}.py`
+- Shared Supabase HTTP pool: `services/api/app/repo/http_client.py` — one process-wide `httpx.AsyncClient` reused by all Supabase adapters, opened/closed in `main.lifespan`
 - Config (pydantic-settings): `services/api/app/config/settings.py`
 - Structural tests: `services/api/tests/test_structure.py`
 - Frontend API client: `apps/web/src/lib/api-client.ts`

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-20 -->
+<!-- last_verified: 2026-07-21 -->
 # Tech Debt Tracker
 
 Known tech debt items. Agents update this when they discover or create tech debt.
@@ -18,11 +18,6 @@ and frontend entitlement-error / global-401 handling.
 
 Deliberately **deferred** (not ship blockers; recorded here after red-team review):
 
-- **Shared httpx client / connection pooling** — every Supabase repo opens a
-  fresh `AsyncClient` (2 round-trips per authed request in `get_current_user`). A
-  lifespan-managed singleton trips pytest-asyncio event-loop reuse and isn't
-  exercised by the (fully monkeypatched) tests, so it needs a real integration
-  test alongside it. Priority: Medium (latency, not correctness).
 - **e2e (Playwright) not in CI** — the 4 journey specs need the full stack
   (Supabase + API + Stripe CLI + mailpit); wiring an ephemeral stack into CI is a
   separate effort. Run locally with `pnpm test:e2e` as a pre-release gate.
@@ -63,6 +58,7 @@ Nitpicks surfaced by the verify pass on the file surface (logged, not blocking; 
 
 | Description | Resolution |
 |---|---|
+| Every Supabase repo opened a fresh `AsyncClient` per call (2 hops per authed request in `get_current_user`), paying TCP+TLS setup each time | Process-wide pooled `httpx.AsyncClient` in `repo/http_client.py`, lifespan-managed with a lazy getter for the TestClient path; a suite-wide autouse reset fixture (`conftest.py`) closes it around each test and `tests/test_http_client.py` exercises reuse/idempotent-close/401 |
 | Double-billing: an active subscriber hitting Checkout opened a 2nd Stripe subscription | `create_checkout_url` 409s an active sub; the billing UI routes existing subscribers to the Billing Portal (`service/billing.py`, `billing/page.tsx`) |
 | Out-of-order Stripe events: a stale/retried `customer.subscription.*` could overwrite newer state (delivery is unordered) | Added `subscriptions.last_event_created_at` (Stripe event `created`) + `apply_subscription_event` Postgres function; the webhook applies subscription events via PostgREST RPC with an atomic `ON CONFLICT … WHERE incoming >= stored` freshness guard, so a staler event is a DB-side no-op (`init.sql`, `repo/supabase_billing.py`, `service/billing.py`) |
 | Open redirect: `safeNextPath` missed control chars the URL parser strips | Reject any `\x00-\x1f\x7f` char pre-parse (`lib/safe-redirect.ts`) |

--- a/services/api/app/repo/http_client.py
+++ b/services/api/app/repo/http_client.py
@@ -1,0 +1,51 @@
+"""Process-wide pooled httpx.AsyncClient shared by the Supabase HTTP adapters.
+
+Every Supabase repo call used to open and tear down its own
+`httpx.AsyncClient`, so the auth hot path (two calls per request via
+`get_current_user`) paid full TCP + TLS setup on every hop. This module owns a
+single client whose connection pool is reused across all Supabase requests. It
+is created on FastAPI startup and closed on shutdown (see `main.lifespan`).
+
+Per-call timeouts are still passed explicitly by each adapter
+(`timeout=_TIMEOUT`), so each repo keeps its own timeout semantics — this client
+only owns the shared connection pool, not the timeout policy.
+"""
+
+import logging
+
+import httpx
+
+logger = logging.getLogger("api")
+
+# Fallback timeout for the shared client. Individual repo calls override this
+# per-request with their own `_TIMEOUT`, so this default is rarely hit.
+_DEFAULT_TIMEOUT = httpx.Timeout(10.0)
+
+_client: httpx.AsyncClient | None = None
+
+
+def get_client() -> httpx.AsyncClient:
+    """Return the shared client, lazily creating one if the lifespan never ran.
+
+    The lazy path keeps tests that drive the app via TestClient/ASGITransport
+    (no startup event) working without wiring the lifespan into every fixture.
+    """
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT)
+        logger.info("Created shared Supabase httpx client")
+    return _client
+
+
+async def init_client() -> None:
+    """Eagerly create the shared client on startup (idempotent)."""
+    get_client()
+
+
+async def close_client() -> None:
+    """Close the shared client on shutdown. Safe to call more than once."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+        logger.info("Closed shared Supabase httpx client")
+    _client = None

--- a/services/api/app/repo/http_client.py
+++ b/services/api/app/repo/http_client.py
@@ -21,6 +21,12 @@ logger = logging.getLogger("api")
 # per-request with their own `_TIMEOUT`, so this default is rarely hit.
 _DEFAULT_TIMEOUT = httpx.Timeout(10.0)
 
+# Make the shared pool's ceiling explicit rather than relying on httpx defaults,
+# so the connection budget is visible and tunable. Sized to the API's likely
+# concurrency (Supabase does ~2 hops per authed request); httpx queues callers
+# beyond the limit rather than erroring.
+_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
+
 _client: httpx.AsyncClient | None = None
 
 
@@ -32,7 +38,7 @@ def get_client() -> httpx.AsyncClient:
     """
     global _client
     if _client is None or _client.is_closed:
-        _client = httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT)
+        _client = httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT, limits=_LIMITS)
         logger.info("Created shared Supabase httpx client")
     return _client
 

--- a/services/api/app/repo/supabase_admin.py
+++ b/services/api/app/repo/supabase_admin.py
@@ -13,6 +13,7 @@ audit-log insert is service-role (append-only, no client policy).
 import httpx
 
 from app.config import settings
+from app.repo import http_client
 
 _TIMEOUT = httpx.Timeout(15.0)
 
@@ -32,12 +33,12 @@ def _service_headers() -> dict[str, str]:
 
 
 async def _list(table: str, params: dict) -> list[dict]:
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(
-            f"{settings.supabase_url}/rest/v1/{table}",
-            params=params,
-            headers=_service_headers(),
-        )
+    resp = await http_client.get_client().get(
+        f"{settings.supabase_url}/rest/v1/{table}",
+        params=params,
+        headers=_service_headers(),
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
     return resp.json()
 
@@ -48,17 +49,17 @@ async def count(table: str, filters: dict | None = None) -> int:
     `Prefer: count=exact` + a 0-0 range returns the total in `Content-Range`
     (e.g. `0-0/123`, or `*/0` when empty) while transferring only one row.
     """
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(
-            f"{settings.supabase_url}/rest/v1/{table}",
-            params=filters or {},
-            headers={
-                **_service_headers(),
-                "Prefer": "count=exact",
-                "Range-Unit": "items",
-                "Range": "0-0",
-            },
-        )
+    resp = await http_client.get_client().get(
+        f"{settings.supabase_url}/rest/v1/{table}",
+        params=filters or {},
+        headers={
+            **_service_headers(),
+            "Prefer": "count=exact",
+            "Range-Unit": "items",
+            "Range": "0-0",
+        },
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
     total = resp.headers.get("content-range", "*/0").rsplit("/", 1)[-1]
     return int(total) if total.isdigit() else 0
@@ -110,12 +111,12 @@ async def list_audit_events(limit: int = 500) -> list[dict]:
 
 async def record_audit_event(row: dict) -> None:
     """Append one audit row (service role; the table has no client write policy)."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.post(
-            f"{settings.supabase_url}/rest/v1/admin_audit_events",
-            headers={**_service_headers(), "Prefer": "return=minimal"},
-            json=row,
-        )
+    resp = await http_client.get_client().post(
+        f"{settings.supabase_url}/rest/v1/admin_audit_events",
+        headers={**_service_headers(), "Prefer": "return=minimal"},
+        json=row,
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
 
 
@@ -127,18 +128,18 @@ async def update_user_role(*, user_id: str, role: str, access_token: str) -> dic
     the RLS `profiles_update_admin` policy gates it to admins. Returns the updated
     row, or None if no row matched.
     """
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.patch(
-            f"{settings.supabase_url}/rest/v1/profiles",
-            params={"id": f"eq.{user_id}"},
-            headers={
-                "apikey": settings.supabase_anon_key,
-                "Authorization": f"Bearer {access_token}",
-                "Content-Type": "application/json",
-                "Prefer": "return=representation",
-            },
-            json={"role": role},
-        )
+    resp = await http_client.get_client().patch(
+        f"{settings.supabase_url}/rest/v1/profiles",
+        params={"id": f"eq.{user_id}"},
+        headers={
+            "apikey": settings.supabase_anon_key,
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "Prefer": "return=representation",
+        },
+        json={"role": role},
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
     rows = resp.json()
     return rows[0] if rows else None

--- a/services/api/app/repo/supabase_auth.py
+++ b/services/api/app/repo/supabase_auth.py
@@ -9,20 +9,21 @@ hosted asymmetric signing keys), so pointing at a hosted project is config-only.
 import httpx
 
 from app.config import settings
+from app.repo import http_client
 
 _TIMEOUT = httpx.Timeout(10.0)
 
 
 async def fetch_user(access_token: str) -> dict | None:
     """Return the Supabase user for a bearer token, or None if it is invalid."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(
-            f"{settings.supabase_url}/auth/v1/user",
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "apikey": settings.supabase_anon_key,
-            },
-        )
+    resp = await http_client.get_client().get(
+        f"{settings.supabase_url}/auth/v1/user",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "apikey": settings.supabase_anon_key,
+        },
+        timeout=_TIMEOUT,
+    )
     if resp.status_code != httpx.codes.OK:
         return None
     return resp.json()
@@ -30,16 +31,16 @@ async def fetch_user(access_token: str) -> dict | None:
 
 async def fetch_profile_role(access_token: str, user_id: str) -> str | None:
     """Read the caller's role from public.profiles via PostgREST (RLS-scoped)."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(
-            f"{settings.supabase_url}/rest/v1/profiles",
-            params={"id": f"eq.{user_id}", "select": "role"},
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "apikey": settings.supabase_anon_key,
-                "Accept": "application/json",
-            },
-        )
+    resp = await http_client.get_client().get(
+        f"{settings.supabase_url}/rest/v1/profiles",
+        params={"id": f"eq.{user_id}", "select": "role"},
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "apikey": settings.supabase_anon_key,
+            "Accept": "application/json",
+        },
+        timeout=_TIMEOUT,
+    )
     if resp.status_code != httpx.codes.OK:
         return None
     rows = resp.json()

--- a/services/api/app/repo/supabase_billing.py
+++ b/services/api/app/repo/supabase_billing.py
@@ -11,6 +11,7 @@ the validated user id but not the caller's raw access token.
 import httpx
 
 from app.config import settings
+from app.repo import http_client
 
 _TIMEOUT = httpx.Timeout(10.0)
 
@@ -31,24 +32,24 @@ def _service_headers() -> dict[str, str]:
 
 async def list_plans() -> list[dict]:
     """Return the public plan catalog ordered cheapest-first."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(
-            f"{settings.supabase_url}/rest/v1/plans",
-            params={"select": "*", "is_public": "eq.true", "order": "rank.asc"},
-            headers=_service_headers(),
-        )
+    resp = await http_client.get_client().get(
+        f"{settings.supabase_url}/rest/v1/plans",
+        params={"select": "*", "is_public": "eq.true", "order": "rank.asc"},
+        headers=_service_headers(),
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
     return resp.json()
 
 
 async def get_subscription(user_id: str) -> dict | None:
     """Return the user's subscription row, or None when they have never subscribed."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(
-            f"{settings.supabase_url}/rest/v1/subscriptions",
-            params={"user_id": f"eq.{user_id}", "select": "*"},
-            headers=_service_headers(),
-        )
+    resp = await http_client.get_client().get(
+        f"{settings.supabase_url}/rest/v1/subscriptions",
+        params={"user_id": f"eq.{user_id}", "select": "*"},
+        headers=_service_headers(),
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
     rows = resp.json()
     return rows[0] if rows else None
@@ -61,13 +62,13 @@ async def upsert_subscription(row: dict) -> None:
     keep their prior value. Used by the checkout path, which writes ONLY the
     Stripe id mapping so it never clobbers a tier/status the subscription event
     already set (see service._sync_from_checkout)."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.post(
-            f"{settings.supabase_url}/rest/v1/subscriptions",
-            params={"on_conflict": "user_id"},
-            headers={**_service_headers(), "Prefer": "resolution=merge-duplicates"},
-            json=row,
-        )
+    resp = await http_client.get_client().post(
+        f"{settings.supabase_url}/rest/v1/subscriptions",
+        params={"on_conflict": "user_id"},
+        headers={**_service_headers(), "Prefer": "resolution=merge-duplicates"},
+        json=row,
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
 
 
@@ -91,33 +92,33 @@ async def apply_subscription_event(row: dict, *, event_created_at: int | None) -
         "p_cancel_at_period_end": row.get("cancel_at_period_end", False),
         "p_event_created_at": event_created_at,
     }
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.post(
-            f"{settings.supabase_url}/rest/v1/rpc/apply_subscription_event",
-            headers=_service_headers(),
-            json=payload,
-        )
+    resp = await http_client.get_client().post(
+        f"{settings.supabase_url}/rest/v1/rpc/apply_subscription_event",
+        headers=_service_headers(),
+        json=payload,
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
 
 
 async def event_seen(event_id: str) -> bool:
     """True when this Stripe event id was already processed (idempotency)."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(
-            f"{settings.supabase_url}/rest/v1/stripe_events",
-            params={"id": f"eq.{event_id}", "select": "id"},
-            headers=_service_headers(),
-        )
+    resp = await http_client.get_client().get(
+        f"{settings.supabase_url}/rest/v1/stripe_events",
+        params={"id": f"eq.{event_id}", "select": "id"},
+        headers=_service_headers(),
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
     return bool(resp.json())
 
 
 async def record_event(event_id: str, event_type: str) -> None:
     """Persist a processed event id; ignore-duplicates keeps this idempotent."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.post(
-            f"{settings.supabase_url}/rest/v1/stripe_events",
-            headers={**_service_headers(), "Prefer": "resolution=ignore-duplicates"},
-            json={"id": event_id, "type": event_type},
-        )
+    resp = await http_client.get_client().post(
+        f"{settings.supabase_url}/rest/v1/stripe_events",
+        headers={**_service_headers(), "Prefer": "resolution=ignore-duplicates"},
+        json={"id": event_id, "type": event_type},
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()

--- a/services/api/app/repo/supabase_generation.py
+++ b/services/api/app/repo/supabase_generation.py
@@ -8,6 +8,7 @@ id from the FastAPI auth dependency. Mirrors supabase_billing.py.
 import httpx
 
 from app.config import settings
+from app.repo import http_client
 
 _TIMEOUT = httpx.Timeout(15.0)
 
@@ -33,16 +34,16 @@ async def count_jobs_since(user_id: str, since_iso: str) -> int:
     failed runs — each attempt spends real provider budget. Uses PostgREST's
     exact-count header so only one row is transferred.
     """
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(
-            f"{settings.supabase_url}/rest/v1/generation_jobs",
-            params={
-                "user_id": f"eq.{user_id}",
-                "created_at": f"gte.{since_iso}",
-                "select": "id",
-            },
-            headers={**_service_headers(), "Prefer": "count=exact", "Range": "0-0"},
-        )
+    resp = await http_client.get_client().get(
+        f"{settings.supabase_url}/rest/v1/generation_jobs",
+        params={
+            "user_id": f"eq.{user_id}",
+            "created_at": f"gte.{since_iso}",
+            "select": "id",
+        },
+        headers={**_service_headers(), "Prefer": "count=exact", "Range": "0-0"},
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
     total = resp.headers.get("content-range", "*/0").rsplit("/", 1)[-1]
     return int(total) if total.isdigit() else 0
@@ -60,12 +61,12 @@ async def create_job(
         "status": "running",
         "seed": seed,
     }
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.post(
-            f"{settings.supabase_url}/rest/v1/generation_jobs",
-            headers={**_service_headers(), "Prefer": "return=representation"},
-            json=row,
-        )
+    resp = await http_client.get_client().post(
+        f"{settings.supabase_url}/rest/v1/generation_jobs",
+        headers={**_service_headers(), "Prefer": "return=representation"},
+        json=row,
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
     rows = resp.json()
     return rows[0] if rows else row
@@ -90,13 +91,13 @@ async def complete_job(
         "cost_usd": cost_usd,
         "error": error,
     }
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.patch(
-            f"{settings.supabase_url}/rest/v1/generation_jobs",
-            params={"id": f"eq.{job_id}"},
-            headers={**_service_headers(), "Prefer": "return=minimal"},
-            json=patch,
-        )
+    resp = await http_client.get_client().patch(
+        f"{settings.supabase_url}/rest/v1/generation_jobs",
+        params={"id": f"eq.{job_id}"},
+        headers={**_service_headers(), "Prefer": "return=minimal"},
+        json=patch,
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
 
 
@@ -104,50 +105,50 @@ async def insert_files(rows: list[dict]) -> None:
     """Insert generated-file rows (idempotent on b2_key)."""
     if not rows:
         return
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.post(
-            f"{settings.supabase_url}/rest/v1/files",
-            params={"on_conflict": "b2_key"},
-            headers={**_service_headers(), "Prefer": "resolution=merge-duplicates,return=minimal"},
-            json=rows,
-        )
+    resp = await http_client.get_client().post(
+        f"{settings.supabase_url}/rest/v1/files",
+        params={"on_conflict": "b2_key"},
+        headers={**_service_headers(), "Prefer": "resolution=merge-duplicates,return=minimal"},
+        json=rows,
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
 
 
 async def record_provider_run(row: dict) -> None:
     """Persist one provider-invocation provenance row."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.post(
-            f"{settings.supabase_url}/rest/v1/provider_runs",
-            headers={**_service_headers(), "Prefer": "return=minimal"},
-            json=row,
-        )
+    resp = await http_client.get_client().post(
+        f"{settings.supabase_url}/rest/v1/provider_runs",
+        headers={**_service_headers(), "Prefer": "return=minimal"},
+        json=row,
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
 
 
 async def record_usage_event(row: dict) -> None:
     """Persist one usage-meter row."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.post(
-            f"{settings.supabase_url}/rest/v1/usage_events",
-            headers={**_service_headers(), "Prefer": "return=minimal"},
-            json=row,
-        )
+    resp = await http_client.get_client().post(
+        f"{settings.supabase_url}/rest/v1/usage_events",
+        headers={**_service_headers(), "Prefer": "return=minimal"},
+        json=row,
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
 
 
 async def list_jobs(user_id: str, *, limit: int = 50) -> list[dict]:
     """Return a user's jobs newest-first, with their generated files embedded."""
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.get(
-            f"{settings.supabase_url}/rest/v1/generation_jobs",
-            params={
-                "user_id": f"eq.{user_id}",
-                "select": "*,files(*)",
-                "order": "created_at.desc",
-                "limit": str(limit),
-            },
-            headers=_service_headers(),
-        )
+    resp = await http_client.get_client().get(
+        f"{settings.supabase_url}/rest/v1/generation_jobs",
+        params={
+            "user_id": f"eq.{user_id}",
+            "select": "*,files(*)",
+            "order": "created_at.desc",
+            "limit": str(limit),
+        },
+        headers=_service_headers(),
+        timeout=_TIMEOUT,
+    )
     resp.raise_for_status()
     return resp.json()

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -18,6 +18,7 @@ from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 
 from app.config import APP_VERSION, settings  # noqa: E402
+from app.repo import http_client  # noqa: E402
 from app.runtime import (  # noqa: E402
     admin,
     auth,
@@ -122,7 +123,15 @@ async def lifespan(_app: "FastAPI"):
             "authentication. Set METRICS_TOKEN on any public deploy so route "
             "templates and traffic/error volumes are not world-readable."
         )
-    yield
+
+    # Open the process-wide Supabase httpx client once so its connection pool is
+    # reused across every request (the auth hot path alone makes two calls per
+    # request); close it on shutdown so the pool drains cleanly.
+    await http_client.init_client()
+    try:
+        yield
+    finally:
+        await http_client.close_client()
 
 # --- Structured JSON logging ---
 

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -75,6 +75,23 @@ def reset_shared_module_state():
 
 
 @pytest.fixture(autouse=True)
+async def reset_shared_http_client():
+    """Close the shared Supabase httpx client before and after each test.
+
+    The pooled client (`repo/http_client.py`) binds its connection pool to the
+    event loop it first issues a request on; pytest-asyncio gives each async
+    test its own loop, so without this a client created in one test would be
+    reused on the next test's loop and raise. Suite-wide (not just the
+    http_client tests) so any future test that drives a real repo path is safe.
+    """
+    from app.repo import http_client
+
+    await http_client.close_client()
+    yield
+    await http_client.close_client()
+
+
+@pytest.fixture(autouse=True)
 def isolate_download_counter(tmp_path, monkeypatch):
     """Redirect the persisted download counter to a temp file per test and
     reset the in-memory counter to 0. Keeps tests hermetic and prevents

--- a/services/api/tests/test_http_client.py
+++ b/services/api/tests/test_http_client.py
@@ -1,0 +1,91 @@
+"""Tests for the shared, pooled Supabase httpx client.
+
+These prove the pooling contract that replaced the per-call
+`async with httpx.AsyncClient(...)`: one client instance is reused across repo
+calls, it is closed idempotently on shutdown, it is lazily recreated when the
+lifespan never ran (the test-drive path), and auth still 401s on a bad token
+end-to-end through the pooled client.
+"""
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.repo import http_client, supabase_billing
+
+
+@pytest.fixture(autouse=True)
+async def _reset_shared_client():
+    """Start and end each test with no shared client so instances never leak
+    across event loops (pytest gives each async test its own loop)."""
+    await http_client.close_client()
+    yield
+    await http_client.close_client()
+
+
+async def test_get_client_returns_same_instance():
+    c1 = http_client.get_client()
+    c2 = http_client.get_client()
+    assert c1 is c2
+    assert not c1.is_closed
+
+
+async def test_close_client_is_idempotent():
+    client = http_client.get_client()
+    await http_client.close_client()
+    assert client.is_closed
+    # A second close (e.g. shutdown after a lazy-close) must not raise.
+    await http_client.close_client()
+
+
+async def test_get_client_recreates_after_close():
+    first = http_client.get_client()
+    await http_client.close_client()
+    second = http_client.get_client()
+    assert second is not first
+    assert not second.is_closed
+
+
+async def test_shared_client_reused_across_repo_calls(monkeypatch):
+    """Two different Supabase repo calls go through the one pooled client."""
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=[])
+
+    shared = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(http_client, "_client", shared)
+    monkeypatch.setattr(settings, "supabase_url", "http://sb.test")
+    monkeypatch.setattr(settings, "supabase_service_role_key", "svc-key")
+
+    await supabase_billing.list_plans()
+    await supabase_billing.get_subscription("u-1")
+
+    # Both hops resolved to the same pooled client, and both were sent.
+    assert http_client.get_client() is shared
+    assert len(requests) == 2
+    await http_client.close_client()
+
+
+async def test_auth_returns_401_on_bad_token(client, monkeypatch):
+    """A bad bearer token still 401s through the real repo/service path when it
+    rides the pooled client (error propagation preserved by the refactor)."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        # Supabase answers GET /auth/v1/user with 401 for an invalid token.
+        return httpx.Response(401, json={"msg": "invalid token"})
+
+    shared = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(http_client, "_client", shared)
+    monkeypatch.setattr(settings, "supabase_url", "http://sb.test")
+
+    resp = await client.get("/me", headers={"Authorization": "Bearer bad"})
+    assert resp.status_code == 401
+    await http_client.close_client()
+
+
+async def test_auth_returns_401_on_absent_token(client):
+    """No Authorization header short-circuits to 401 before any client call."""
+    resp = await client.get("/me")
+    assert resp.status_code == 401

--- a/services/api/tests/test_http_client.py
+++ b/services/api/tests/test_http_client.py
@@ -8,19 +8,12 @@ end-to-end through the pooled client.
 """
 
 import httpx
-import pytest
 
 from app.config import settings
 from app.repo import http_client, supabase_billing
 
-
-@pytest.fixture(autouse=True)
-async def _reset_shared_client():
-    """Start and end each test with no shared client so instances never leak
-    across event loops (pytest gives each async test its own loop)."""
-    await http_client.close_client()
-    yield
-    await http_client.close_client()
+# The shared client is reset before/after every test by the suite-wide autouse
+# `reset_shared_http_client` fixture in conftest.py, so no local fixture here.
 
 
 async def test_get_client_returns_same_instance():


### PR DESCRIPTION
## Problem
Every authenticated request opens and tears down a fresh `httpx.AsyncClient` per Supabase call. The auth hot path is the worst offender: `get_current_user` alone makes **two** such calls per request (`GET /auth/v1/user` + a `profiles` role read), each paying full TCP + TLS connection setup with zero reuse. All four Supabase repos (`supabase_auth`, `supabase_billing`, `supabase_admin`, `supabase_generation`) do this on every call.

## Fix
Introduce a process-wide **pooled** `httpx.AsyncClient` in the repo layer:

- New `services/api/app/repo/http_client.py` owns a single shared client (`get_client()` / `init_client()` / `close_client()`).
- Created on FastAPI **startup** and closed on **shutdown** via the existing `main.lifespan`.
- The four Supabase adapters now call `http_client.get_client().<verb>(...)` instead of `async with httpx.AsyncClient(...)`, reusing one connection pool across all requests.

Layering respected: the shared client lives in `repo/`; `main.py` (runtime) wires it into the lifespan (runtime → repo is allowed); no boto3/stripe involved.

## Behavior preserved
- Each adapter keeps its own `_TIMEOUT` and headers, now passed **per-request** (`timeout=_TIMEOUT`), so the 10s auth/billing and 15s admin/generation timeouts are unchanged.
- `raise_for_status` / status-code error propagation is identical — only connection reuse changes.
- **Test shield:** `get_client()` lazily creates a client if the lifespan never ran, so existing `TestClient`/`ASGITransport` suites (which don't trigger startup) keep working. `close_client()` is idempotent.

## Explicitly NOT included
- **No auth caching.** No caching of users, tokens, roles, or auth decisions. A TTL auth cache is deliberately out of scope here for security reasons and handled separately. This PR is connection pooling only.

## Tests
Added `tests/test_http_client.py`: shared client is the same object across repo calls, is closed idempotently on shutdown, is lazily recreated after close, and auth still returns 401 on a bad and on an absent token (end-to-end through the pooled client).

## Verification
⚠️ Verification pending — the test suite was **not** run locally (central verifier runs the gates). Locally confirmed: `py_compile` clean on all changed files and `ruff check` passes on them.