### PR TITLE
perf: cache Supabase identity lookup (role never cached)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 # fallback above. Leave them unset for a single .env.
 # SUPABASE_URL=
 # SUPABASE_ANON_KEY=
+# Security/perf knob (optional): TTL (seconds) for caching the per-request
+# identity lookup. Default 30. Drops one of the two Supabase round-trips per
+# authenticated request on a warm hit. Role is NEVER cached (fetched live), so
+# no privilege-escalation window — but a revoked/expired token stays accepted
+# for up to this TTL. Set to 0 to revalidate identity on every request.
+# AUTH_CACHE_TTL_SECONDS=30
 
 # --- AI media generation: NVIDIA NIM (optional to boot) ---
 # Powers the /generate workflow (text-to-image via flux.1-dev), orchestrated

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -19,6 +19,15 @@ Security principles and implementation for the ai-saas-starter-kit.
   trusting `getSession()`.
 - The API validates bearer tokens by calling Supabase `/auth/v1/user` (portable across
   local HS256 and hosted asymmetric signing keys — no secret assumptions).
+- **Identity is cached; authorization is not.** The `/auth/v1/user` identity lookup is
+  memoized for a short TTL (`AUTH_CACHE_TTL_SECONDS`, default 30s), keyed by a SHA-256
+  hash of the bearer token (never the raw token, so plaintext tokens aren't held in
+  memory). This drops one of the two per-request Supabase round-trips on a warm hit. The
+  role/authorization decision (`/rest/v1/profiles`) is **never cached** — it is fetched
+  live on every request, so a demoted admin loses access immediately (no
+  privilege-escalation window). Tradeoff: a revoked or rotated token stays accepted for
+  up to the TTL because identity is cached. Set `AUTH_CACHE_TTL_SECONDS=0` to disable the
+  cache and revalidate identity on every request.
 - **Row Level Security** is enabled on `profiles` and `roles`: a user reads/updates only
   their own profile; admins (`is_admin()`) may read/update all. A trigger
   (`prevent_role_escalation`) blocks non-admins from changing their own role.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -25,9 +25,13 @@ Security principles and implementation for the ai-saas-starter-kit.
   memory). This drops one of the two per-request Supabase round-trips on a warm hit. The
   role/authorization decision (`/rest/v1/profiles`) is **never cached** — it is fetched
   live on every request, so a demoted admin loses access immediately (no
-  privilege-escalation window). Tradeoff: a revoked or rotated token stays accepted for
-  up to the TTL because identity is cached. Set `AUTH_CACHE_TTL_SECONDS=0` to disable the
-  cache and revalidate identity on every request.
+  privilege-escalation window). Tradeoff: what the cache skips is the identity/liveness
+  check, so a token is honored for up to the TTL past its **expiry or revocation** (not
+  just rotation) — bounded and low-risk here because Supabase access tokens are already
+  bearer-valid until their own ~1h `exp` regardless of logout, and **privilege escalation
+  is impossible** (a stale admin token's live role fetch fails and downgrades to `user`).
+  Set `AUTH_CACHE_TTL_SECONDS=0` to disable the cache and revalidate identity on every
+  request.
 - **Row Level Security** is enabled on `profiles` and `roles`: a user reads/updates only
   their own profile; admins (`is_admin()`) may read/update all. A trigger
   (`prevent_role_escalation`) blocks non-admins from changing their own role.

--- a/services/api/app/config/settings.py
+++ b/services/api/app/config/settings.py
@@ -33,6 +33,14 @@ class Settings(BaseSettings):
     # every plans/subscriptions read/write, so it is required at startup (main.py).
     supabase_service_role_key: str = ""
 
+    # Short-TTL cache for the per-request Supabase IDENTITY lookup
+    # (GET /auth/v1/user), keyed by a hash of the bearer token. Cuts one of the
+    # two auth round-trips on a warm hit. Only identity (user id + email) is
+    # cached — the role/authorization decision is ALWAYS fetched live, so a
+    # demoted admin loses access immediately. Tradeoff: a revoked/rotated token
+    # stays accepted for up to this many seconds. Set to 0 to disable the cache.
+    auth_cache_ttl_seconds: int = 30
+
     # Stripe billing. All optional to boot: billing endpoints return a clean 503
     # when a key is missing, so the auth + file-manager scaffold runs without
     # Stripe configured. Test-mode keys look like sk_test_… / whsec_…; get them

--- a/services/api/app/service/auth.py
+++ b/services/api/app/service/auth.py
@@ -1,16 +1,80 @@
-"""Auth business logic: turn a raw access token into a validated AuthUser."""
+"""Auth business logic: turn a raw access token into a validated AuthUser.
 
+Identity (who a token belongs to) is served from a short-TTL cache to drop one
+of the two Supabase round-trips an authenticated request otherwise makes. The
+role/authorization decision is NEVER cached — it is fetched live on every
+request, so a demoted admin loses access immediately (no privilege-escalation
+window). See docs/SECURITY.md (Authentication & Authorization).
+"""
+
+import hashlib
+import time
+
+from app.config import settings
 from app.repo import supabase_auth
 from app.types.auth import AuthUser
+
+# Short-TTL identity cache: sha256(token) hex -> (expiry_monotonic, (id, email)).
+# Keyed by a hash, never the raw token, so bearer tokens aren't held in memory
+# in plaintext. Requests share one event loop and there is no `await` between
+# reading and using an entry, so a plain dict is safe without a lock; the size
+# cap bounds memory under token churn.
+_IDENTITY_CACHE_MAX = 10_000  # cap distinct cached tokens (bounds memory)
+_identity_cache: dict[str, tuple[float, tuple[str, str | None]]] = {}
+
+
+def _reset_cache() -> None:
+    """Drop all cached identities (test hook)."""
+    _identity_cache.clear()
+
+
+def _token_key(access_token: str) -> str:
+    """Hash the token so the raw bearer value never lands in the cache keyspace."""
+    return hashlib.sha256(access_token.encode("utf-8")).hexdigest()
+
+
+def _cached_identity(key: str) -> tuple[str, str | None] | None:
+    """Return a still-fresh cached identity for `key`, or None on miss/expiry."""
+    entry = _identity_cache.get(key)
+    if entry is not None and time.monotonic() < entry[0]:
+        return entry[1]
+    return None
+
+
+def _store_identity(key: str, identity: tuple[str, str | None], ttl: float) -> None:
+    """Cache `identity` under `key`, purging expired entries then capping size."""
+    now = time.monotonic()
+    if key not in _identity_cache and len(_identity_cache) >= _IDENTITY_CACHE_MAX:
+        # Purge anything already expired first; only if still at capacity do we
+        # evict the soonest-to-expire entry, so churn can't grow the dict.
+        for expired in [k for k, (exp, _) in _identity_cache.items() if exp <= now]:
+            del _identity_cache[expired]
+        if len(_identity_cache) >= _IDENTITY_CACHE_MAX:
+            del _identity_cache[min(_identity_cache, key=lambda k: _identity_cache[k][0])]
+    _identity_cache[key] = (now + ttl, identity)
 
 
 async def user_from_token(access_token: str) -> AuthUser | None:
     """Validate the token with Supabase and enrich it with the app role.
 
-    Returns None when the token is missing/invalid so callers can raise 401.
+    The identity lookup (GET /auth/v1/user) is served from a short-TTL cache when
+    warm; the role (GET /rest/v1/profiles) is ALWAYS fetched live so an
+    authorization decision is never stale. Returns None when the token is
+    missing/invalid so callers can raise 401.
     """
-    user = await supabase_auth.fetch_user(access_token)
-    if not user or not user.get("id"):
-        return None
-    role = await supabase_auth.fetch_profile_role(access_token, user["id"]) or "user"
-    return AuthUser(id=user["id"], email=user.get("email"), role=role)
+    ttl = settings.auth_cache_ttl_seconds
+    key = _token_key(access_token) if ttl > 0 else None
+
+    identity = _cached_identity(key) if key is not None else None
+    if identity is None:
+        user = await supabase_auth.fetch_user(access_token)
+        if not user or not user.get("id"):
+            return None  # invalid token — never cached as valid
+        identity = (user["id"], user.get("email"))
+        if key is not None:
+            _store_identity(key, identity, ttl)
+
+    user_id, email = identity
+    # Role/authorization is fetched live on EVERY request — see module docstring.
+    role = await supabase_auth.fetch_profile_role(access_token, user_id) or "user"
+    return AuthUser(id=user_id, email=email, role=role)

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -161,3 +161,31 @@ async def test_ttl_zero_disables_cache(auth_service, monkeypatch):
     assert counts["user"] == 2  # no caching — identity fetched every time
     assert counts["role"] == 2
     assert auth_service._identity_cache == {}  # nothing stored
+
+
+def test_cache_is_bounded_and_purges_expired_first(auth_service, monkeypatch):
+    """The store caps the cache: expired entries are purged first, and if still
+    at capacity the soonest-to-expire live entry is evicted — so token churn
+    can't grow the dict unboundedly."""
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(auth_service.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(auth_service, "_IDENTITY_CACHE_MAX", 3)
+
+    # Fill to capacity with live entries (ttl 100 → expire at 1100).
+    for i in range(3):
+        auth_service._store_identity(f"k{i}", (f"u-{i}", None), ttl=100)
+    assert len(auth_service._identity_cache) == 3
+
+    # A new key at capacity with everything live evicts the soonest-to-expire
+    # (k0, stored first) — never exceeding the cap.
+    auth_service._store_identity("k-new", ("u-new", None), ttl=100)
+    assert len(auth_service._identity_cache) == 3
+    assert "k0" not in auth_service._identity_cache
+    assert "k-new" in auth_service._identity_cache
+
+    # Advance past the live entries' expiry; a further store purges the expired
+    # ones instead of evicting a live entry, and stays bounded.
+    clock["t"] = 1200.0
+    auth_service._store_identity("k-fresh", ("u-fresh", None), ttl=100)
+    assert len(auth_service._identity_cache) == 1
+    assert "k-fresh" in auth_service._identity_cache

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -7,6 +7,7 @@ the service boundary so the dependency/route behavior is covered hermetically.
 import pytest
 from fastapi import HTTPException
 
+from app.config import settings
 from app.runtime.auth import require_admin
 from app.types.auth import AuthUser
 
@@ -62,3 +63,101 @@ async def test_require_admin_rejects_non_admin():
 async def test_require_admin_allows_admin():
     admin = AuthUser(id="u", email=None, role="admin")
     assert await require_admin(admin) is admin
+
+
+# --- Identity cache (service layer) -------------------------------------------
+#
+# These exercise user_from_token directly, stubbing the repo round-trips with
+# call counters. The contract under test: identity (GET /auth/v1/user) is cached
+# for a short TTL, but the role (GET /rest/v1/profiles) is fetched live EVERY
+# request so an authorization decision is never stale.
+
+
+def _counting_repo_stubs(monkeypatch, *, user=None, role="user"):
+    """Stub the two Supabase repo calls with [user_calls, role_calls] counters."""
+    from app.repo import supabase_auth
+
+    counts = {"user": 0, "role": 0}
+
+    async def fake_fetch_user(_token):
+        counts["user"] += 1
+        return user
+
+    async def fake_fetch_profile_role(_token, _user_id):
+        counts["role"] += 1
+        return role
+
+    monkeypatch.setattr(supabase_auth, "fetch_user", fake_fetch_user)
+    monkeypatch.setattr(supabase_auth, "fetch_profile_role", fake_fetch_profile_role)
+    return counts
+
+
+@pytest.fixture
+def auth_service():
+    """The auth service module with its identity cache cleared before/after."""
+    from app.service import auth as auth_service
+
+    auth_service._reset_cache()
+    try:
+        yield auth_service
+    finally:
+        auth_service._reset_cache()
+
+
+@pytest.mark.asyncio
+async def test_identity_cached_but_role_fetched_live(auth_service, monkeypatch):
+    """Within TTL the identity endpoint is hit ONCE; the role is re-fetched."""
+    monkeypatch.setattr(settings, "auth_cache_ttl_seconds", 30)
+    counts = _counting_repo_stubs(monkeypatch, user={"id": "u-1", "email": "a@b.co"})
+
+    first = await auth_service.user_from_token("tok")
+    second = await auth_service.user_from_token("tok")
+
+    assert first == second == AuthUser(id="u-1", email="a@b.co", role="user")
+    assert counts["user"] == 1  # identity served from cache on the 2nd call
+    assert counts["role"] == 2  # role always fetched live
+
+
+@pytest.mark.asyncio
+async def test_identity_cache_expiry_rehits_identity(auth_service, monkeypatch):
+    """After the TTL lapses, the identity endpoint is hit again."""
+    monkeypatch.setattr(settings, "auth_cache_ttl_seconds", 30)
+    counts = _counting_repo_stubs(monkeypatch, user={"id": "u-1", "email": None})
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(auth_service.time, "monotonic", lambda: clock["t"])
+
+    await auth_service.user_from_token("tok")
+    clock["t"] += 31  # advance past the 30s TTL
+    await auth_service.user_from_token("tok")
+
+    assert counts["user"] == 2  # entry expired, identity re-fetched
+    assert counts["role"] == 2
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_not_cached_as_valid(auth_service, monkeypatch):
+    """A bad token returns None every time — never cached, role never reached."""
+    monkeypatch.setattr(settings, "auth_cache_ttl_seconds", 30)
+    counts = _counting_repo_stubs(monkeypatch, user=None)
+
+    assert await auth_service.user_from_token("bad") is None
+    assert await auth_service.user_from_token("bad") is None
+
+    assert counts["user"] == 2  # re-validated each call (not cached as valid)
+    assert counts["role"] == 0  # never reached for an invalid token
+    assert auth_service._identity_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_ttl_zero_disables_cache(auth_service, monkeypatch):
+    """TTL=0 disables caching: identity is hit on every request."""
+    monkeypatch.setattr(settings, "auth_cache_ttl_seconds", 0)
+    counts = _counting_repo_stubs(monkeypatch, user={"id": "u-1", "email": "a@b.co"})
+
+    await auth_service.user_from_token("tok")
+    await auth_service.user_from_token("tok")
+
+    assert counts["user"] == 2  # no caching — identity fetched every time
+    assert counts["role"] == 2
+    assert auth_service._identity_cache == {}  # nothing stored


### PR DESCRIPTION
## The win

\`user_from_token\` made **two** sequential Supabase round-trips per authenticated request: \`GET /auth/v1/user\` (token -> identity) and \`GET /rest/v1/profiles\` (identity -> role). This branch adds a short-TTL in-process cache for the **identity** lookup, so a warm request drops **one of the two** round-trips.

## Strict rule: role/authorization is NEVER cached

- **Cached:** the identity only — user id + email — keyed by \`sha256(token)\` hex (never the raw token, so bearer tokens aren't held in memory in plaintext).
- **Never cached:** the role / authorization decision. \`fetch_profile_role\` runs **live on every request**, so a demoted admin loses access immediately. There is no privilege-escalation window. This is the whole point of the design.

## Setting

\`AUTH_CACHE_TTL_SECONDS\` (default **30**). Set to **0** to disable caching entirely and revalidate identity on every request.

## Tradeoff (documented in docs/SECURITY.md)

A revoked or rotated token stays accepted for up to the TTL because identity is cached. Role is always current. Disable with \`AUTH_CACHE_TTL_SECONDS=0\` if you need immediate token-revocation semantics.

## Bounds & safety

- Single event loop, no \`await\` between reading and using a cache entry, so a plain dict is safe without a lock.
- Size-capped (max entries) with expired-first eviction, falling back to evicting the soonest-to-expire entry, so token churn can't grow the cache unboundedly.
- Invalid tokens return \`None\` and are never cached as valid.

## Tests (services/api/tests/test_auth.py)

- identity cached within TTL: \`fetch_user\` called **1x**, \`fetch_profile_role\` called **2x** across two calls.
- expiry re-hits identity: after advancing past TTL, \`fetch_user\` **2x**, \`fetch_profile_role\` **2x**.
- invalid token not cached: \`fetch_user\` **2x**, \`fetch_profile_role\` **0x**, cache empty.
- \`TTL=0\` disables cache: \`fetch_user\` **2x**, \`fetch_profile_role\` **2x**, cache empty.

## Verification

Verification pending — the central verifier runs the CI gates. The suite was **not** run locally; \`py_compile\` and \`ruff check\` pass on the changed files.