### PR TITLE
fix(billing): guard against out-of-order Stripe subscription events

### DIFF
--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -18,11 +18,6 @@ and frontend entitlement-error / global-401 handling.
 
 Deliberately **deferred** (not ship blockers; recorded here after red-team review):
 
-- **Stripe event-ordering guard** — a stale/retried `subscription.*` event can
-  still overwrite newer state. A correct fix needs a schema migration (add e.g.
-  `last_stripe_event_at`; compare the *event's* `created`, since a Subscription's
-  own `created` is constant) + read-compare-write. Lower-frequency than the
-  double-billing clobber that was fixed. Priority: Medium.
 - **Shared httpx client / connection pooling** — every Supabase repo opens a
   fresh `AsyncClient` (2 round-trips per authed request in `get_current_user`). A
   lifespan-managed singleton trips pytest-asyncio event-loop reuse and isn't
@@ -69,6 +64,7 @@ Nitpicks surfaced by the verify pass on the file surface (logged, not blocking; 
 | Description | Resolution |
 |---|---|
 | Double-billing: an active subscriber hitting Checkout opened a 2nd Stripe subscription | `create_checkout_url` 409s an active sub; the billing UI routes existing subscribers to the Billing Portal (`service/billing.py`, `billing/page.tsx`) |
+| Out-of-order Stripe events: a stale/retried `customer.subscription.*` could overwrite newer state (delivery is unordered) | Added `subscriptions.last_event_created_at` (Stripe event `created`) + `apply_subscription_event` Postgres function; the webhook applies subscription events via PostgREST RPC with an atomic `ON CONFLICT … WHERE incoming >= stored` freshness guard, so a staler event is a DB-side no-op (`init.sql`, `repo/supabase_billing.py`, `service/billing.py`) |
 | Open redirect: `safeNextPath` missed control chars the URL parser strips | Reject any `\x00-\x1f\x7f` char pre-parse (`lib/safe-redirect.ts`) |
 | Unbounded upload body spooled to disk before the size check (disk DoS) | ASGI `BodySizeLimitMiddleware` rejects on Content-Length AND meters the stream, inner to CORS (`runtime/bodylimit.py`) |
 | Generation could starve the shared request threadpool (leaked timed-out threads) | Blocking pipeline runs on a dedicated bounded `ThreadPoolExecutor` (`service/generation.py`) |

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -74,9 +74,16 @@ reusable plan-gating dependency that locks features behind a tier.
   race on the same per-user row. Because checkout writes only id columns (and the
   merge-upsert overwrites only the columns it sends), a paid `pro`/`active` row is
   never clobbered back to `free`/`incomplete` regardless of which lands last.
-  A stale/retried `customer.subscription.updated` overwriting newer state is a
-  narrower remaining gap (needs an event-timestamp guard + a schema column) —
-  tracked in the tech-debt tracker, not yet closed.
+- Out-of-order subscription events: Stripe does not guarantee ordered delivery, so
+  a stale/retried `customer.subscription.*` can arrive after a newer one. Each
+  subscription event carries the Stripe **event** `created` (unix seconds), stored
+  as `subscriptions.last_event_created_at`. The webhook applies events through the
+  `apply_subscription_event` Postgres function (via PostgREST RPC), whose
+  `ON CONFLICT` branch fires only when the incoming event is same-or-newer (or
+  ordering is impossible — first event on the row, or a missing timestamp). A
+  staler event is a no-op DB-side, so the freshness check is atomic and cannot
+  race under concurrent deliveries (no read-compare-write in the API). The
+  checkout id-only path keeps its plain merge-upsert.
 
 ## UX States
 - Empty/Free: three plan cards, current plan = `FREE`, Pro preview locked.
@@ -89,8 +96,12 @@ reusable plan-gating dependency that locks features behind a tier.
 - Required cases: webhook signature verify (good/bad/missing secret), idempotent
   sync, deletion→downgrade, `require_plan` 402/allow, checkout 503-without-config,
   `checkout.session.completed` not clobbering an active paid row (either ordering)
-  and recording the id mapping without unlocking, and the live e2e webhook upgrade
-  unlocking Pro.
+  and recording the id mapping without unlocking, out-of-order subscription events
+  (stale=no-op, newer applies, first-on-new-row applies, missing timestamp applies)
+  plus the RPC-payload shape for `apply_subscription_event`, and the live e2e
+  webhook upgrade unlocking Pro. NOTE: the SQL freshness guard itself is not
+  executed by the hermetic pytest suite (no live Postgres) — it is covered by the
+  RPC-payload assertion and manual/e2e DB runs.
 - Quick verify command: `pnpm test:api` (billing unit tests, hermetic).
 - Full verify command: `supabase start` + `pnpm dev`, then `pnpm test:e2e`.
   The webhook-upgrade e2e also needs `STRIPE_WEBHOOK_SECRET` +

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -83,7 +83,17 @@ reusable plan-gating dependency that locks features behind a tier.
   ordering is impossible — first event on the row, or a missing timestamp). A
   staler event is a no-op DB-side, so the freshness check is atomic and cannot
   race under concurrent deliveries (no read-compare-write in the API). The
-  checkout id-only path keeps its plain merge-upsert.
+  checkout id-only path keeps its plain merge-upsert. `event.created` is
+  second-granular and the compare is `>=`, so two genuinely distinct events in
+  the *same second* are last-delivered-wins — an inherent limit, acceptable
+  because same-second state flips are rare and idempotent retries are caught by
+  `stripe_events`.
+- **Applying this schema change:** the `last_event_created_at` column and
+  `apply_subscription_event` function live in the consolidated init migration
+  (`00000000000000_init.sql`). A DB that already ran an earlier `init.sql` will
+  **not** pick them up from `supabase start` / `supabase db push` (that version
+  is recorded as applied) — run `supabase db reset` locally, or reset/recreate
+  the hosted DB, after pulling. A fresh clone gets them on first `supabase start`.
 
 ## UX States
 - Empty/Free: three plan cards, current plan = `FREE`, Pro preview locked.

--- a/services/api/app/repo/supabase_billing.py
+++ b/services/api/app/repo/supabase_billing.py
@@ -55,13 +55,47 @@ async def get_subscription(user_id: str) -> dict | None:
 
 
 async def upsert_subscription(row: dict) -> None:
-    """Insert or update the per-user subscription row (conflict on user_id)."""
+    """Merge-upsert the per-user subscription row (conflict on user_id).
+
+    ON CONFLICT overwrites only the columns present in `row`; omitted columns
+    keep their prior value. Used by the checkout path, which writes ONLY the
+    Stripe id mapping so it never clobbers a tier/status the subscription event
+    already set (see service._sync_from_checkout)."""
     async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
         resp = await client.post(
             f"{settings.supabase_url}/rest/v1/subscriptions",
             params={"on_conflict": "user_id"},
             headers={**_service_headers(), "Prefer": "resolution=merge-duplicates"},
             json=row,
+        )
+    resp.raise_for_status()
+
+
+async def apply_subscription_event(row: dict, *, event_created_at: int | None) -> None:
+    """Apply a customer.subscription.* event to the user's row, rejecting stale
+    ones. Delegates to the `apply_subscription_event` Postgres function via RPC
+    so the freshness comparison against `last_event_created_at` is atomic in the
+    DB — a read-compare-write here would race under concurrent webhook
+    deliveries (Stripe does not guarantee ordered delivery). An out-of-order
+    (older) event is a no-op server-side.
+
+    `event_created_at` is the Stripe EVENT's `created` (unix seconds), NOT the
+    Subscription object's constant `created`."""
+    payload = {
+        "p_user_id": row["user_id"],
+        "p_plan_id": row["plan_id"],
+        "p_status": row["status"],
+        "p_stripe_customer_id": row.get("stripe_customer_id"),
+        "p_stripe_subscription_id": row.get("stripe_subscription_id"),
+        "p_current_period_end": row.get("current_period_end"),
+        "p_cancel_at_period_end": row.get("cancel_at_period_end", False),
+        "p_event_created_at": event_created_at,
+    }
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            f"{settings.supabase_url}/rest/v1/rpc/apply_subscription_event",
+            headers=_service_headers(),
+            json=payload,
         )
     resp.raise_for_status()
 

--- a/services/api/app/service/billing.py
+++ b/services/api/app/service/billing.py
@@ -165,7 +165,13 @@ async def handle_webhook(payload: bytes, sig_header: str) -> dict:
 
     obj = event["data"]["object"]
     if event_type in _SUBSCRIPTION_EVENTS:
-        await _sync_subscription(obj, deleted=event_type.endswith("deleted"))
+        # event["created"] (unix seconds) orders subscription events; a staler
+        # one is rejected DB-side (see repo.apply_subscription_event).
+        await _sync_subscription(
+            obj,
+            deleted=event_type.endswith("deleted"),
+            event_created_at=event.get("created"),
+        )
     elif event_type == "checkout.session.completed":
         await _sync_from_checkout(obj)
 
@@ -174,8 +180,13 @@ async def handle_webhook(payload: bytes, sig_header: str) -> dict:
     return {"status": "processed", "id": event_id, "type": event_type}
 
 
-async def _sync_subscription(sub_obj: dict, *, deleted: bool) -> None:
-    """Upsert the per-user subscription row from a Stripe Subscription object."""
+async def _sync_subscription(
+    sub_obj: dict, *, deleted: bool, event_created_at: int | None
+) -> None:
+    """Upsert the per-user subscription row from a Stripe Subscription object.
+
+    `event_created_at` is the enclosing Stripe event's `created` timestamp; it
+    lets the repo reject an out-of-order (staler) event DB-side."""
     user_id = (sub_obj.get("metadata") or {}).get("user_id")
     if not user_id:
         logger.warning(
@@ -214,7 +225,7 @@ async def _sync_subscription(sub_obj: dict, *, deleted: bool) -> None:
         "current_period_end": _iso_from_unix(period_end),
         "cancel_at_period_end": bool(sub_obj.get("cancel_at_period_end", False)),
     }
-    await supabase_billing.upsert_subscription(row)
+    await supabase_billing.apply_subscription_event(row, event_created_at=event_created_at)
 
 
 async def _sync_from_checkout(session_obj: dict) -> None:

--- a/services/api/tests/test_billing.py
+++ b/services/api/tests/test_billing.py
@@ -12,6 +12,7 @@ import hmac
 import json
 import time
 
+import httpx
 import pytest
 from fastapi import HTTPException
 
@@ -39,10 +40,14 @@ def _sub_event(
     status: str = "active",
     event_type: str = "customer.subscription.updated",
     event_id: str = "evt_test_1",
+    created: int | None = 1_700_000_000,
 ) -> dict:
     return {
         "id": event_id,
         "type": event_type,
+        # Stripe EVENT.created (unix seconds) — orders subscription events. Pass
+        # created=None to model a webhook whose timestamp is absent.
+        "created": created,
         "data": {
             "object": {
                 "id": "sub_test_1",
@@ -105,6 +110,21 @@ class FakeBillingStore:
         base = self.subs.get(uid) or db_defaults
         self.subs[uid] = {**base, **row}
 
+    async def apply_subscription_event(self, row: dict, *, event_created_at: int | None) -> None:
+        # Model the `apply_subscription_event` Postgres function's freshness
+        # guard: the ON CONFLICT branch fires only when the incoming event is
+        # same-or-newer, or ordering is impossible (row has no prior event, or
+        # the incoming event has no timestamp). A staler event is a no-op.
+        uid = row["user_id"]
+        existing = self.subs.get(uid)
+        if existing is not None:
+            prev = existing.get("last_event_created_at")
+            if prev is not None and event_created_at is not None and event_created_at < prev:
+                return  # staler event — DB WHERE guard rejects it
+        db_defaults = {"plan_id": "free", "status": "inactive", "cancel_at_period_end": False}
+        base = existing or db_defaults
+        self.subs[uid] = {**base, **row, "last_event_created_at": event_created_at}
+
     async def get_subscription(self, user_id: str) -> dict | None:
         return self.subs.get(user_id)
 
@@ -112,7 +132,13 @@ class FakeBillingStore:
 @pytest.fixture
 def fake_store(monkeypatch):
     store = FakeBillingStore()
-    for name in ("event_seen", "record_event", "upsert_subscription", "get_subscription"):
+    for name in (
+        "event_seen",
+        "record_event",
+        "upsert_subscription",
+        "apply_subscription_event",
+        "get_subscription",
+    ):
         monkeypatch.setattr(supabase_billing, name, getattr(store, name))
     return store
 
@@ -190,6 +216,155 @@ async def test_webhook_deletion_downgrades_to_free(monkeypatch, fake_store):
     row = fake_store.subs["u-1"]
     assert row["plan_id"] == "free"
     assert row["status"] == "canceled"
+
+
+# --- out-of-order subscription events (event-ordering guard) ---------------
+# Stripe does not guarantee ordered delivery, so a stale/retried
+# customer.subscription.* can arrive after a newer one. The freshness guard
+# lives in the `apply_subscription_event` Postgres function; these tests mock
+# the repo, so they assert the SERVICE threads the event's `created` through and
+# that the guard's semantics (modelled in FakeBillingStore) hold. They do NOT
+# execute the SQL — the guard itself is exercised by the RPC-payload test below
+# plus manual/e2e DB runs.
+
+
+@pytest.mark.asyncio
+async def test_stale_subscription_update_is_noop(monkeypatch, fake_store):
+    """(a) An older customer.subscription.updated arriving AFTER a newer one
+    must not overwrite the newer state."""
+    monkeypatch.setattr(billing_service.settings, "stripe_price_pro", "price_pro_test")
+    monkeypatch.setattr(billing_service.settings, "stripe_price_team", "price_team_test")
+
+    # Newer event lands first: team/active at t=2000.
+    newer = _sub_event(
+        price_id="price_team_test", event_id="evt_new", created=2_000_000_000
+    )
+    monkeypatch.setattr(stripe_client, "construct_event", lambda p, s: newer)
+    await billing_service.handle_webhook(b"{}", "sig")
+    assert fake_store.subs["u-1"]["plan_id"] == "team"
+
+    # Older event (t=1000) is processed last — it downgrades to pro in its
+    # payload but must be rejected by the freshness guard.
+    older = _sub_event(
+        price_id="price_pro_test", event_id="evt_old", created=1_000_000_000
+    )
+    monkeypatch.setattr(stripe_client, "construct_event", lambda p, s: older)
+    await billing_service.handle_webhook(b"{}", "sig")
+
+    row = fake_store.subs["u-1"]
+    assert row["plan_id"] == "team", "stale event clobbered newer tier"
+    assert row["last_event_created_at"] == 2_000_000_000
+
+
+@pytest.mark.asyncio
+async def test_newer_subscription_update_applies(monkeypatch, fake_store):
+    """(b) A newer event arriving after an older one applies normally."""
+    monkeypatch.setattr(billing_service.settings, "stripe_price_pro", "price_pro_test")
+    monkeypatch.setattr(billing_service.settings, "stripe_price_team", "price_team_test")
+
+    older = _sub_event(
+        price_id="price_pro_test", event_id="evt_a", created=1_000_000_000
+    )
+    monkeypatch.setattr(stripe_client, "construct_event", lambda p, s: older)
+    await billing_service.handle_webhook(b"{}", "sig")
+    assert fake_store.subs["u-1"]["plan_id"] == "pro"
+
+    newer = _sub_event(
+        price_id="price_team_test", event_id="evt_b", created=2_000_000_000
+    )
+    monkeypatch.setattr(stripe_client, "construct_event", lambda p, s: newer)
+    await billing_service.handle_webhook(b"{}", "sig")
+
+    row = fake_store.subs["u-1"]
+    assert row["plan_id"] == "team"
+    assert row["last_event_created_at"] == 2_000_000_000
+
+
+@pytest.mark.asyncio
+async def test_first_subscription_event_applies_on_new_row(monkeypatch, fake_store):
+    """(c) The first subscription event on a brand-new row applies (no prior
+    last_event_created_at to compare against)."""
+    monkeypatch.setattr(billing_service.settings, "stripe_price_pro", "price_pro_test")
+    evt = _sub_event(event_id="evt_first", created=1_500_000_000)
+    monkeypatch.setattr(stripe_client, "construct_event", lambda p, s: evt)
+
+    await billing_service.handle_webhook(b"{}", "sig")
+
+    row = fake_store.subs["u-1"]
+    assert row["plan_id"] == "pro"
+    assert row["status"] == "active"
+    assert row["last_event_created_at"] == 1_500_000_000
+
+
+@pytest.mark.asyncio
+async def test_absent_event_created_still_applies(monkeypatch, fake_store):
+    """(d) A webhook with no `created` timestamp can't be ordered, so it must
+    still apply (guard treats NULL as 'apply') and land None in the column."""
+    monkeypatch.setattr(billing_service.settings, "stripe_price_pro", "price_pro_test")
+    evt = _sub_event(event_id="evt_no_ts", created=None)
+    monkeypatch.setattr(stripe_client, "construct_event", lambda p, s: evt)
+
+    await billing_service.handle_webhook(b"{}", "sig")
+
+    row = fake_store.subs["u-1"]
+    assert row["plan_id"] == "pro"
+    assert row["last_event_created_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_apply_subscription_event_builds_rpc_call(monkeypatch):
+    """The repo must POST the subscription-event upsert to the RPC endpoint with
+    the p_-prefixed function params (incl. the event's created timestamp) and
+    the service-role auth headers. This asserts the request the DB function
+    receives; the SQL guard itself is not executed here (no live Postgres)."""
+    monkeypatch.setattr(supabase_billing.settings, "supabase_url", "https://db.example")
+    monkeypatch.setattr(
+        supabase_billing.settings, "supabase_service_role_key", "svc-role-key"
+    )
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["method"] = request.method
+        captured["auth"] = request.headers.get("Authorization")
+        captured["apikey"] = request.headers.get("apikey")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(204)
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        supabase_billing.httpx,
+        "AsyncClient",
+        lambda **kw: real_client(transport=transport, **kw),
+    )
+
+    row = {
+        "user_id": "u-1",
+        "plan_id": "pro",
+        "status": "active",
+        "stripe_customer_id": "cus_1",
+        "stripe_subscription_id": "sub_1",
+        "current_period_end": "2030-01-01T00:00:00+00:00",
+        "cancel_at_period_end": False,
+    }
+    await supabase_billing.apply_subscription_event(row, event_created_at=1_700_000_000)
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://db.example/rest/v1/rpc/apply_subscription_event"
+    assert captured["auth"] == "Bearer svc-role-key"
+    assert captured["apikey"] == "svc-role-key"
+    assert captured["body"] == {
+        "p_user_id": "u-1",
+        "p_plan_id": "pro",
+        "p_status": "active",
+        "p_stripe_customer_id": "cus_1",
+        "p_stripe_subscription_id": "sub_1",
+        "p_current_period_end": "2030-01-01T00:00:00+00:00",
+        "p_cancel_at_period_end": False,
+        "p_event_created_at": 1_700_000_000,
+    }
 
 
 @pytest.mark.asyncio

--- a/supabase/migrations/00000000000000_init.sql
+++ b/supabase/migrations/00000000000000_init.sql
@@ -217,6 +217,13 @@ create table if not exists public.subscriptions (
   stripe_subscription_id text,
   current_period_end     timestamptz,
   cancel_at_period_end   boolean not null default false,
+  -- Stripe EVENT.created (unix seconds) of the last subscription event applied
+  -- to this row. Used to reject out-of-order webhooks: Stripe does not
+  -- guarantee ordered delivery, so a stale/retried customer.subscription.*
+  -- can arrive after a newer one. NOT the Subscription object's own `created`
+  -- (that is constant for the life of the subscription and useless for
+  -- ordering). NULL until the first subscription event lands.
+  last_event_created_at  bigint,
   created_at             timestamptz not null default now(),
   updated_at             timestamptz not null default now()
 );
@@ -230,6 +237,57 @@ comment on table public.subscriptions is
 create trigger subscriptions_set_updated_at
   before update on public.subscriptions
   for each row execute function public.set_updated_at();
+
+-- Out-of-order-safe subscription upsert ---------------------------------------
+-- Stripe does not guarantee ordered webhook delivery, so a stale or retried
+-- customer.subscription.* event can arrive AFTER a newer one and overwrite
+-- current state with stale data. This function makes the freshness check
+-- ATOMIC in the DB (not a read-compare-write in the API, which would race
+-- under concurrent webhook deliveries): the ON CONFLICT branch applies only
+-- when the incoming event is at least as new as the last one applied to the
+-- row. A staler event is silently a no-op.
+--
+-- p_event_created_at is the Stripe EVENT's `created` (unix seconds). NULL is
+-- treated as "cannot order — apply it" so a missing timestamp never drops an
+-- update (idempotency is still handled separately by stripe_events).
+--
+-- Called by the webhook path via PostgREST RPC with the service role; the
+-- explicit grant below makes it reachable (service_role bypasses RLS anyway).
+create or replace function public.apply_subscription_event(
+  p_user_id                uuid,
+  p_plan_id                text,
+  p_status                 text,
+  p_stripe_customer_id     text,
+  p_stripe_subscription_id text,
+  p_current_period_end     timestamptz,
+  p_cancel_at_period_end   boolean,
+  p_event_created_at       bigint
+)
+returns void
+language sql
+security definer
+set search_path = public
+as $$
+  insert into public.subscriptions as s (
+    user_id, plan_id, status, stripe_customer_id, stripe_subscription_id,
+    current_period_end, cancel_at_period_end, last_event_created_at
+  )
+  values (
+    p_user_id, p_plan_id, p_status, p_stripe_customer_id, p_stripe_subscription_id,
+    p_current_period_end, p_cancel_at_period_end, p_event_created_at
+  )
+  on conflict (user_id) do update set
+    plan_id                = excluded.plan_id,
+    status                 = excluded.status,
+    stripe_customer_id     = excluded.stripe_customer_id,
+    stripe_subscription_id = excluded.stripe_subscription_id,
+    current_period_end     = excluded.current_period_end,
+    cancel_at_period_end   = excluded.cancel_at_period_end,
+    last_event_created_at  = excluded.last_event_created_at
+  where s.last_event_created_at is null              -- row has no applied event yet
+     or excluded.last_event_created_at is null       -- incoming event is unordered
+     or excluded.last_event_created_at >= s.last_event_created_at;  -- same-or-newer wins
+$$;
 
 -- Processed Stripe events (webhook idempotency) -------------------------------
 create table if not exists public.stripe_events (
@@ -272,6 +330,11 @@ grant select on public.plans to anon, authenticated, service_role;
 grant select on public.subscriptions to authenticated, service_role;
 grant insert, update on public.subscriptions to service_role;
 grant select, insert on public.stripe_events to service_role;
+-- The webhook applies subscription events through this function (out-of-order
+-- guard); the service role calls it via PostgREST RPC.
+grant execute on function public.apply_subscription_event(
+  uuid, text, text, text, text, timestamptz, boolean, bigint
+) to service_role;
 
 -- =============================================================================
 -- GENERATION — jobs, generated files, provider runs, usage meter

--- a/supabase/migrations/00000000000000_init.sql
+++ b/supabase/migrations/00000000000000_init.sql
@@ -249,10 +249,23 @@ create trigger subscriptions_set_updated_at
 --
 -- p_event_created_at is the Stripe EVENT's `created` (unix seconds). NULL is
 -- treated as "cannot order — apply it" so a missing timestamp never drops an
--- update (idempotency is still handled separately by stripe_events).
+-- update (idempotency is still handled separately by stripe_events). Caveat: a
+-- NULL-timestamped event also WRITES NULL back to last_event_created_at,
+-- re-disarming the guard until the next non-NULL event lands — harmless for
+-- Stripe (event.created is always set) but relevant to any adapter that omits
+-- it. Ordering is second-granular, and the comparison is `>=`, so two distinct
+-- events in the SAME second are last-delivered-wins (an inherent limit, not a
+-- regression — same-second state flips are rare and retries are idempotent).
 --
--- Called by the webhook path via PostgREST RPC with the service role; the
--- explicit grant below makes it reachable (service_role bypasses RLS anyway).
+-- Called by the webhook path via PostgREST RPC with the service role. It is
+-- SECURITY INVOKER (runs with the caller's privileges), NOT definer: the write
+-- to public.subscriptions therefore succeeds only for a role that actually
+-- holds insert/update on that table (service_role). A DEFINER function here
+-- would be an entitlement-forgery hole — PostgREST exposes public-schema RPCs
+-- and Postgres grants EXECUTE to PUBLIC by default, so as definer any anon
+-- caller could forge a paid plan for an arbitrary p_user_id. As invoker, anon/
+-- authenticated (which lack the table grant) get permission denied; the
+-- explicit REVOKE below removes even EXECUTE from PUBLIC for defense in depth.
 create or replace function public.apply_subscription_event(
   p_user_id                uuid,
   p_plan_id                text,
@@ -265,8 +278,7 @@ create or replace function public.apply_subscription_event(
 )
 returns void
 language sql
-security definer
-set search_path = public
+security invoker
 as $$
   insert into public.subscriptions as s (
     user_id, plan_id, status, stripe_customer_id, stripe_subscription_id,
@@ -335,6 +347,12 @@ grant select, insert on public.stripe_events to service_role;
 grant execute on function public.apply_subscription_event(
   uuid, text, text, text, text, timestamptz, boolean, bigint
 ) to service_role;
+-- Remove the PUBLIC default EXECUTE grant so only service_role can call the
+-- RPC (defense in depth; SECURITY INVOKER already blocks the table write for
+-- anon/authenticated, but this keeps the RPC off the anon-reachable surface).
+revoke execute on function public.apply_subscription_event(
+  uuid, text, text, text, text, timestamptz, boolean, bigint
+) from public;
 
 -- =============================================================================
 -- GENERATION — jobs, generated files, provider runs, usage meter


### PR DESCRIPTION
## Problem

Stripe does not guarantee ordered webhook delivery. A stale or retried `customer.subscription.*` event can arrive **after** a newer one and overwrite current subscription state with stale data (e.g. downgrade a `team` row back to `pro`, or reactivate a canceled one). Deferred tech-debt item: "Stripe event-ordering guard".

**Not in scope:** the checkout-vs-subscription clobber — already fixed in `fdffb2b` (checkout writes only the Stripe id columns). This PR does not touch that path.

## Mechanism (race-free, DB-side)

A read-compare-write in Python would reintroduce a TOCTOU under concurrent webhook deliveries, so the freshness check is made atomic in Postgres:

1. **New column** `subscriptions.last_event_created_at bigint` — stores the Stripe **event's** `created` (unix seconds) of the last applied event. (Not the Subscription object's own `created`, which is constant for the life of the subscription and useless for ordering.)
2. **New function** `public.apply_subscription_event(...)` — an `INSERT … ON CONFLICT (user_id) DO UPDATE … WHERE` whose update branch fires only when the incoming event is same-or-newer, or ordering is impossible (row has no prior event / incoming timestamp is NULL). A staler event is a silent no-op.

   ```sql
   where s.last_event_created_at is null
      or excluded.last_event_created_at is null
      or excluded.last_event_created_at >= s.last_event_created_at
   ```
3. **Repo** (`repo/supabase_billing.py`) — the subscription-event path now calls the function via PostgREST RPC (`POST /rest/v1/rpc/apply_subscription_event`) with the service-role key, replacing the blind merge-upsert. The checkout id-only merge-upsert (`upsert_subscription`) is unchanged, preserving `fdffb2b`'s no-clobber behavior.
4. **Service** (`service/billing.py`) — `handle_webhook` threads `event["created"]` into `_sync_subscription`, which passes it to the repo.

Single consolidated init migration is edited directly (starter-kit convention); RLS/grants intact, plus a `grant execute … to service_role` for the new function.

## Tests (`tests/test_billing.py`)

- (a) older `subscription.updated` after a newer one → no-op
- (b) newer event after an older one → applies
- (c) first event on a brand-new row → applies
- (d) absent/NULL event `created` → still applies (can't be ordered)
- repo RPC-payload test: asserts the URL, service-role headers, and `p_`-prefixed body (incl. `p_event_created_at`)

Existing checkout-clobber and idempotency tests still pass through the updated `FakeBillingStore`, which now models the freshness guard.

## Caveat: SQL not exercised in CI

The hermetic pytest suite mocks the repo/PostgREST layer — there is **no live Postgres**, so the SQL `WHERE` guard itself is not executed by CI. It is covered by the RPC-payload assertion (service passes the right event `created`; repo builds the right RPC call) plus manual/e2e DB runs. The service-level ordering tests model the guard's semantics in `FakeBillingStore`.

## Verification

**Verification pending** — the full gate suite was **not** run locally (central verifier runs `pnpm lint && test:web && lint:api && test:api && check:structure`). Changed Python was `py_compile`-checked only. Both changed source files stay under the 300-line limit.