### PR TITLE
refactor!: remove legacy /files/{key} routes + client fallback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-15 -->
+<!-- last_verified: 2026-07-21 -->
 # Architecture
 
 ## Components
@@ -109,8 +109,8 @@ See [docs/SECURITY.md](docs/SECURITY.md) for full security documentation.
 - **Billing**: Browser -> `POST /billing/checkout` -> Stripe Checkout (redirect) -> Stripe -> `POST /billing/webhook` (signature-verified) -> `service/billing.py` upserts the subscription into Supabase (service role). `require_plan(min_tier)` reads the derived entitlements and 402s below the required tier.
 - **Upload**: Browser -> `POST /upload` (multipart) -> API validates -> service orchestrates -> repo writes to B2 -> metadata extracted -> response
 - **List**: Browser -> `GET /files` -> service calls repo -> returns file list
-- **Download**: Browser -> `GET /files-by-key/download?key=...` -> service validates key -> repo generates presigned URL -> browser downloads
-- **Delete**: Browser -> `DELETE /files-by-key?key=...` -> service validates key -> repo deletes from B2
+- **Download**: Browser -> `GET /files-by-key/download?key=...` -> service validates + ownership-scopes the key -> repo generates presigned URL -> browser downloads
+- **Delete**: Browser -> `DELETE /files-by-key?key=...` -> service validates + ownership-scopes the key -> repo deletes from B2
 
 ## Observability
 

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -10,63 +10,33 @@ import {
 
 type FileKeyOperation = {
   call: (key: string) => Promise<unknown>;
-  legacyPath: (key: string) => string;
   method: "GET" | "DELETE";
   name: string;
   path: string;
-  unsafeFallbackKeys: { key: string }[];
 };
 
+// The client only ever addresses a file through the `/files-by-key/*` routes,
+// always sending the object key as a query parameter.
 const operations: FileKeyOperation[] = [
-  {
-    call: getFile,
-    legacyPath: (key) => `/files/${encodeURIComponent(key)}`,
-    method: "GET",
-    name: "getFile",
-    path: "/files-by-key/metadata",
-    unsafeFallbackKeys: [
-      "stats",
-      "stats/activity",
-      "payroll/download",
-      "payroll/preview",
-      "reports/download",
-      "reports/preview",
-      "../secret.txt",
-      "uploads/%2e%2e/secret.txt",
-    ].map((key) => ({ key })),
-  },
+  { call: getFile, method: "GET", name: "getFile", path: "/files-by-key/metadata" },
   {
     call: getDownloadUrl,
-    legacyPath: (key) => `/files/${encodeURIComponent(key)}/download`,
     method: "GET",
     name: "getDownloadUrl",
     path: "/files-by-key/download",
-    unsafeFallbackKeys: ["../secret.txt", "uploads/%2e%2e/secret.txt"].map((key) => ({
-      key,
-    })),
   },
   {
     call: getPreviewUrl,
-    legacyPath: (key) => `/files/${encodeURIComponent(key)}/preview`,
     method: "GET",
     name: "getPreviewUrl",
     path: "/files-by-key/preview",
-    unsafeFallbackKeys: ["../secret.txt", "uploads/%2e%2e/secret.txt"].map((key) => ({
-      key,
-    })),
   },
-  {
-    call: deleteFile,
-    legacyPath: (key) => `/files/${encodeURIComponent(key)}`,
-    method: "DELETE",
-    name: "deleteFile",
-    path: "/files-by-key",
-    unsafeFallbackKeys: ["../secret.txt", "uploads/%2e%2e/secret.txt"].map((key) => ({
-      key,
-    })),
-  },
+  { call: deleteFile, method: "DELETE", name: "deleteFile", path: "/files-by-key" },
 ];
 
+// Keys with slashes, spaces, reserved route names, and traversal-shaped input:
+// all must ride in the query string untouched — never a path segment — so the
+// server sees the raw key and applies its own validation/ownership checks.
 const keyCases = [
   "folder/file.txt",
   "folder/file #1?.txt",
@@ -123,60 +93,31 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe.each(operations)(
-  "$name",
-  ({ call, legacyPath, method, path, unsafeFallbackKeys }) => {
-    it.each(keyCases)("sends '$key' as a query parameter", async ({ key }) => {
-      await call(key);
+describe.each(operations)("$name", ({ call, method, path }) => {
+  it.each(keyCases)("sends '$key' as a query parameter", async ({ key }) => {
+    await call(key);
 
-      expect(requestedPath()).toBe(`${path}?${new URLSearchParams({ key })}`);
-      const init = fetchMock.mock.calls[0][1];
-      expect(init?.method ?? "GET").toBe(method);
+    expect(requestedPath()).toBe(`${path}?${new URLSearchParams({ key })}`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1];
+    expect(init?.method ?? "GET").toBe(method);
+  });
+
+  it("rejects empty keys before making a request", async () => {
+    await expectEmptyKeyRejected(call);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates a 404 from the by-key route without any fallback attempt", async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404, "File not found"));
+
+    await expect(call("uploads/report final.txt")).rejects.toMatchObject({
+      message: "File not found",
+      status: 404,
     });
 
-    it("rejects empty keys before making a request", async () => {
-      await expectEmptyKeyRejected(call);
-
-      expect(fetchMock).not.toHaveBeenCalled();
-    });
-
-    it("falls back to the legacy route when the query route is unavailable", async () => {
-      const key = "uploads/report final.txt";
-      fetchMock
-        .mockResolvedValueOnce(errorResponse(404, "Not Found"))
-        .mockResolvedValueOnce(jsonResponse({ key }));
-
-      await call(key);
-
-      expect(requestedPath(0)).toBe(`${path}?${new URLSearchParams({ key })}`);
-      expect(requestedPath(1)).toBe(legacyPath(key));
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    it("does not fall back when the current API reports a missing file", async () => {
-      const key = "stats";
-      fetchMock.mockResolvedValueOnce(errorResponse(404, "File not found"));
-
-      await expect(call(key)).rejects.toMatchObject({
-        message: "File not found",
-        status: 404,
-      });
-
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-    });
-
-    it.each(unsafeFallbackKeys)(
-      "does not fall back for unsafe legacy path key '$key'",
-      async ({ key }) => {
-        fetchMock.mockResolvedValueOnce(errorResponse(404, "Not Found"));
-
-        await expect(call(key)).rejects.toMatchObject({
-          message: "Current API version required for this file key",
-          status: 404,
-        });
-
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-      }
-    );
-  }
-);
+    // Exactly one request — there is no second (legacy) route to fall back to.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -99,57 +99,14 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json();
 }
 
-function isEndpointUnavailable(error: unknown): error is ApiError {
-  return (
-    error instanceof ApiError &&
-    error.status === 404 &&
-    (error.message === "Not Found" || error.message === "API error: 404")
-  );
-}
-
-async function apiFetchWithLegacyFallback<T>(
-  path: string,
-  legacyPath: () => string,
-  init?: RequestInit
-): Promise<T> {
-  try {
-    return await apiFetch<T>(path, init);
-  } catch (error) {
-    if (isEndpointUnavailable(error)) {
-      return apiFetch<T>(legacyPath(), init);
-    }
-    throw error;
-  }
-}
-
+// Object keys are always sent as a query parameter (never a path segment) so
+// slashes, spaces, and reserved route names like `stats` can't be decoded into
+// a colliding path. The API validates/owns the key server-side.
 function fileKeyQuery(key: string): string {
   if (key.length === 0) {
     throw new ApiError("File key is required", 400);
   }
   return new URLSearchParams({ key }).toString();
-}
-
-function legacyFileKeyPath(
-  key: string,
-  options: { blockRouteCollisions?: boolean } = {}
-): string {
-  if (!isLegacyPathFallbackSafe(key, options)) {
-    throw new ApiError("Current API version required for this file key", 404);
-  }
-  return encodeURIComponent(key);
-}
-
-function isLegacyPathFallbackSafe(
-  key: string,
-  { blockRouteCollisions = false }: { blockRouteCollisions?: boolean } = {}
-): boolean {
-  if (/(\.\.\/|\/\.\.|\\|%2e%2e|%00|\x00)/i.test(key)) return false;
-  if (!blockRouteCollisions) return true;
-
-  const lowerKey = key.toLowerCase();
-  if (lowerKey === "stats" || lowerKey === "stats/activity") return false;
-  if (lowerKey.endsWith("/download") || lowerKey.endsWith("/preview")) return false;
-  return true;
 }
 
 export async function getHealth() {
@@ -169,34 +126,22 @@ export async function getUploadActivity(days = 7) {
 }
 
 export async function getFile(key: string) {
-  return apiFetchWithLegacyFallback<FileMetadata>(
-    `/files-by-key/metadata?${fileKeyQuery(key)}`,
-    () => `/files/${legacyFileKeyPath(key, { blockRouteCollisions: true })}`
-  );
+  return apiFetch<FileMetadata>(`/files-by-key/metadata?${fileKeyQuery(key)}`);
 }
 
 export async function getDownloadUrl(key: string) {
-  return apiFetchWithLegacyFallback<{ url: string }>(
-    `/files-by-key/download?${fileKeyQuery(key)}`,
-    () => `/files/${legacyFileKeyPath(key)}/download`
-  );
+  return apiFetch<{ url: string }>(`/files-by-key/download?${fileKeyQuery(key)}`);
 }
 
 /** Preview-only presigned URL — does NOT increment the download counter. */
 export async function getPreviewUrl(key: string) {
-  return apiFetchWithLegacyFallback<{ url: string }>(
-    `/files-by-key/preview?${fileKeyQuery(key)}`,
-    () => `/files/${legacyFileKeyPath(key)}/preview`
-  );
+  return apiFetch<{ url: string }>(`/files-by-key/preview?${fileKeyQuery(key)}`);
 }
 
 export async function deleteFile(key: string) {
-  return apiFetchWithLegacyFallback<{ deleted: boolean; key: string }>(
+  return apiFetch<{ deleted: boolean; key: string }>(
     `/files-by-key?${fileKeyQuery(key)}`,
-    () => `/files/${legacyFileKeyPath(key)}`,
-    {
-      method: "DELETE",
-    }
+    { method: "DELETE" }
   );
 }
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-16 -->
+<!-- last_verified: 2026-07-21 -->
 # Security
 
 Security principles and implementation for the ai-saas-starter-kit.
@@ -75,7 +75,7 @@ Security principles and implementation for the ai-saas-starter-kit.
 
 ## File Surface: Authentication & Per-User Isolation
 
-- **Every file route is authenticated.** `GET /files`, `GET /files/stats`, `GET /files/stats/activity`, the `/files-by-key/*` and legacy `/files/{key}` reads/deletes, and `POST /upload` all depend on `get_current_user`; a missing or invalid bearer token returns `401`. (Rate limiting runs ahead of auth, so abusive unauthenticated traffic is still throttled per IP.)
+- **Every file route is authenticated.** `GET /files`, `GET /files/stats`, `GET /files/stats/activity`, the `/files-by-key/*` reads/deletes, and `POST /upload` all depend on `get_current_user`; a missing or invalid bearer token returns `401`. (Rate limiting runs ahead of auth, so abusive unauthenticated traffic is still throttled per IP.)
 - **Reads/listings are scoped to the caller.** Listings and stats cover only the union of the caller's `uploads/{user_id}/` and `generated/{user_id}/` prefixes — never a bucket-wide scan — so one tenant cannot see another's uploads or generated media.
 - **Writes are scoped to the caller.** Uploaded objects are keyed under `uploads/{user_id}/…`, not a flat `uploads/…`, so users' uploads never collide with or shadow each other.
 - **Ownership is enforced on key-addressed ops.** `metadata`/`download`/`preview`/`delete` for a key outside the caller's own prefixes return `404` — not `403` — so a guessed key never confirms another user's object exists, and no user can read or delete another user's object.

--- a/docs/exec-plans/completed/2026-02-14-download-count.md
+++ b/docs/exec-plans/completed/2026-02-14-download-count.md
@@ -11,5 +11,5 @@
 2. Update types in API and shared package for `total_downloads`.
 3. Wire UI stats card to show the new value.
 4. Update dashboard feature doc to remove placeholder language.
-5. Add tests for `/files/stats` and `/files/{key}/download` increment behavior.
+5. Add tests for `/files/stats` and `/files/{key}/download` (now `/files-by-key/download`) increment behavior.
 

--- a/docs/features/file-browser.md
+++ b/docs/features/file-browser.md
@@ -1,4 +1,4 @@
-<!-- last_verified: 2026-07-16 -->
+<!-- last_verified: 2026-07-21 -->
 # Feature: File Browser
 
 ## Purpose
@@ -10,7 +10,8 @@ Every file route is **authenticated** — a request without a valid Supabase bea
 ## Used By
 - UI: `/files` page, file browser component
 - API (all authenticated, per-user scoped): `GET /files`, `GET /files/stats`, `GET /files/stats/activity`, `GET /files-by-key/metadata?key=...`, `GET /files-by-key/download?key=...`, `GET /files-by-key/preview?key=...`, `DELETE /files-by-key?key=...`
-- Legacy API: `GET /files/{key}`, `GET /files/{key}/download`, `GET /files/{key}/preview`, `DELETE /files/{key}`
+
+Key-addressed operations are served **only** by the query-param `/files-by-key/*` routes; there is no path-segment `/files/{key}` family.
 
 ## Core Functions
 - `apps/web/src/components/files/file-browser.tsx` — tree view container with loading, empty, error, refresh, preview, download, and delete flows
@@ -40,7 +41,6 @@ The listing is always scoped to the authenticated caller (the union of their upl
 - `GET /files-by-key/download?key=...` → `{ url: string }` (presigned URL, attachment disposition, 10-min expiry). Increments the `total_downloads` counter exposed on `/files/stats`. The counter is persisted via `repo/counter.py` to `services/api/data/download_count.json` (override via `DOWNLOAD_COUNT_FILE`). It survives a local process restart; see [RELIABILITY.md](../RELIABILITY.md#stateful-counters--durability-caveats) for its limits on ephemeral filesystems and across replicas.
 - `GET /files-by-key/preview?key=...` → `{ url: string }` (presigned URL for inline rendering, 10-min expiry). Does **not** increment the download counter — used by the preview modal for images / PDFs.
 - `DELETE /files-by-key?key=...` → `{ deleted: true, key: string }`
-- Legacy `/files/{key}` routes remain available for compatibility. The web client uses them only as a rolling-deploy fallback when `/files-by-key` is unavailable and the key is safe to place in a legacy path.
 - Side effects: DELETE removes file from B2; `/download` increments the in-memory download counter
 
 ## Flow
@@ -52,7 +52,6 @@ The listing is always scoped to the authenticated caller (the union of their upl
 - Download: fetches presigned URL via `/files-by-key/download?key=...` (attachment disposition, 10-min expiry), opens in new tab, bumps the download counter, triggers a stats refresh
 - Delete: calls `DELETE /files-by-key?key=...`, removes row from tree, shows toast
 - All key-based API calls send the key in the query string and validate it against path-traversal patterns in the API service layer
-- During frontend/API version skew, the web client falls back to legacy path routes only for keys that cannot collide with reserved file routes such as stats, download, or preview.
 
 ## Edge Cases
 - No / invalid bearer token → API returns 401 (before any key handling)

--- a/services/api/app/runtime/files.py
+++ b/services/api/app/runtime/files.py
@@ -119,28 +119,3 @@ def delete_file_by_key_endpoint(
     key: str, current_user: AuthUser = Depends(get_current_user)
 ):
     return _delete_file_response(current_user.id, key)
-
-
-@router.get("/files/{key:path}/download")
-def download_file_endpoint(
-    key: str, current_user: AuthUser = Depends(get_current_user)
-):
-    return _file_url_response(current_user.id, key, preview=False)
-
-
-@router.get("/files/{key:path}/preview")
-def preview_file_endpoint(
-    key: str, current_user: AuthUser = Depends(get_current_user)
-):
-    """Return a presigned URL for inline preview. Does not count as a download."""
-    return _file_url_response(current_user.id, key, preview=True)
-
-
-@router.get("/files/{key:path}", response_model=FileMetadata)
-def get_file_endpoint(key: str, current_user: AuthUser = Depends(get_current_user)):
-    return _file_metadata_response(current_user.id, key)
-
-
-@router.delete("/files/{key:path}")
-def delete_file_endpoint(key: str, current_user: AuthUser = Depends(get_current_user)):
-    return _delete_file_response(current_user.id, key)

--- a/services/api/tests/test_delete.py
+++ b/services/api/tests/test_delete.py
@@ -17,7 +17,7 @@ async def test_delete_propagates_error(auth_client, monkeypatch):
         lambda key: (_ for _ in ()).throw(RuntimeError("B2 delete failed")),
     )
 
-    response = await auth_client.delete(f"/files/{OWNED_KEY}")
+    response = await auth_client.delete("/files-by-key", params={"key": OWNED_KEY})
     assert response.status_code == 500
     assert "Failed to delete file" in response.json()["detail"]
 
@@ -26,7 +26,7 @@ async def test_delete_propagates_error(auth_client, monkeypatch):
 async def test_delete_success(auth_client, monkeypatch):
     monkeypatch.setattr(files_service, "delete_file", lambda key: None)
 
-    response = await auth_client.delete(f"/files/{OWNED_KEY}")
+    response = await auth_client.delete("/files-by-key", params={"key": OWNED_KEY})
     assert response.status_code == 200
     assert response.json()["deleted"] is True
 
@@ -37,12 +37,14 @@ async def test_delete_foreign_key_404s_without_touching_b2(auth_client, monkeypa
     calls: list[str] = []
     monkeypatch.setattr(files_service, "delete_file", lambda key: calls.append(key))
 
-    response = await auth_client.delete("/files/uploads/other-user/test.txt")
+    response = await auth_client.delete(
+        "/files-by-key", params={"key": "uploads/other-user/test.txt"}
+    )
     assert response.status_code == 404
     assert calls == []
 
 
 @pytest.mark.asyncio
 async def test_delete_requires_auth(client):
-    response = await client.delete(f"/files/{OWNED_KEY}")
+    response = await client.delete("/files-by-key", params={"key": OWNED_KEY})
     assert response.status_code == 401

--- a/services/api/tests/test_download_stats.py
+++ b/services/api/tests/test_download_stats.py
@@ -43,8 +43,8 @@ async def test_downloads_increment_stats(auth_client, monkeypatch):
     assert response.status_code == 200
     assert response.json()["total_downloads"] == 0
 
-    await auth_client.get(f"/files/{OWNED_KEY}/download")
-    await auth_client.get(f"/files/{OWNED_KEY}/download")
+    await auth_client.get("/files-by-key/download", params={"key": OWNED_KEY})
+    await auth_client.get("/files-by-key/download", params={"key": OWNED_KEY})
 
     response = await auth_client.get("/files/stats")
     assert response.status_code == 200
@@ -63,7 +63,9 @@ async def test_preview_does_not_increment_downloads(auth_client, monkeypatch):
     )
 
     for _ in range(3):
-        response = await auth_client.get(f"/files/{OWNED_KEY}/preview")
+        response = await auth_client.get(
+            "/files-by-key/preview", params={"key": OWNED_KEY}
+        )
         assert response.status_code == 200
         assert response.json()["url"] == "https://example.com/preview"
 

--- a/services/api/tests/test_error_handling.py
+++ b/services/api/tests/test_error_handling.py
@@ -69,7 +69,8 @@ async def test_download_not_found_returns_404(auth_client, monkeypatch):
     monkeypatch.setattr(files_service, "get_file_metadata", lambda key: None)
 
     response = await auth_client.get(
-        f"/files/uploads/{TEST_USER_ID}/missing.txt/download"
+        "/files-by-key/download",
+        params={"key": f"uploads/{TEST_USER_ID}/missing.txt"},
     )
     assert response.status_code == 404
     assert "not found" in response.json()["detail"].lower()


### PR DESCRIPTION
## BREAKING CHANGE

The path-segment `/files/{key}` route family is **removed**. Key-addressed file operations are now served exclusively by the query-param `/files-by-key/*` routes. Any client addressing a file by path segment must switch to `/files-by-key/*` with the object key as a `key` query parameter. Approved as its own PR.

## Removed

**Backend (`services/api/app/runtime/files.py`)**
- `GET /files/{key:path}` (metadata)
- `GET /files/{key:path}/download`
- `GET /files/{key:path}/preview`
- `DELETE /files/{key:path}`

**Frontend (`apps/web/src/lib/api-client.ts`)**
- `apiFetchWithLegacyFallback`
- `isEndpointUnavailable`
- `legacyFileKeyPath`
- `isLegacyPathFallbackSafe` (incl. `blockRouteCollisions`)

`getFile` / `getDownloadUrl` / `getPreviewUrl` / `deleteFile` now call `/files-by-key/*` directly.

## Kept (unchanged behavior)

- `/files-by-key/{metadata,download,preview}` + `DELETE /files-by-key` — same auth (401), same per-user ownership scoping (**404-not-403**, no existence leak), same responses.
- Collection routes: `GET /files`, `GET /files/stats`, `GET /files/stats/activity`, `POST /upload`.
- `ApiError` shape and `fileKeyQuery` (empty-key 400 guard) intact.

## Test port summary

- `apps/web/src/lib/api-client.test.ts` — dropped fallback-only cases (legacy-path fallback, unsafe-fallback-key rejection); kept/ported query-param construction, empty-key rejection, and added a "404 propagates with no fallback attempt" assertion.
- `services/api/tests/test_delete.py` — 500-propagation, success, foreign-key 404, and auth cases ported to `DELETE /files-by-key?key=...`.
- `services/api/tests/test_download_stats.py` — download-increment and preview-no-increment ported to `/files-by-key/{download,preview}`.
- `services/api/tests/test_error_handling.py` — missing-file 404 ported to `/files-by-key/download`.
- `test_file_key_routes.py`, `test_key_prefix.py`, `test_rate_limit.py` already targeted `/files-by-key/*` only — no change.

## Doc updates

- `ARCHITECTURE.md` — Download/Delete data-flow lines now reference `/files-by-key/*`.
- `docs/SECURITY.md` — removed the legacy `/files/{key}` mention from the file-surface section.
- `docs/features/file-browser.md` — dropped the legacy API family + fallback descriptions; clarified `/files-by-key/*` is the only key-addressed family.
- `docs/exec-plans/tech-debt-tracker.md` — no change; it has no fallback reference.

## Overlap / merge risk

Another in-flight branch, `chore/config-and-docs-hygiene` (#6), also edits `api-client.ts` (the `prefix` param) and the docs. A rebase/merge-order conflict is expected in `api-client.ts` and possibly the docs. Flagging, not resolving here — resolve at merge time.

## Verification

Suite was **NOT run locally** — the central verifier runs the gates (`pnpm lint`, `test:web`, `build`, `lint:api`, `test:api`, `check:structure`). Locally only `python3 -m py_compile` passed on the changed Python. Verification pending.