### PR TITLE
fix(generation): never strand jobs; stop leaking provider error text

### DIFF
--- a/docs/features/generation.md
+++ b/docs/features/generation.md
@@ -53,7 +53,13 @@ and its outputs also appear in the B2-backed file manager.
   thread can't be force-killed) can't starve file I/O or `/health`. NVIDIA
   returns the image inline (base64); the sink transfers it + a manifest to B2.
 - Service marks the job `succeeded`, mirrors each asset into `public.files`,
-  records the provider run + a usage event, and returns the job.
+  records the provider run + a usage event, and returns the job. The
+  running→terminal transition (`complete_job`) is guarded on its own: if it fails
+  after a paid, B2-written run the job is best-effort marked `failed` and the
+  caller gets a clean `502` — a job never lingers as `running`. The **secondary**
+  bookkeeping writes (provider run, file rows, usage event) log-and-continue on
+  failure and never flip an already-`succeeded` job to `failed` (that would prompt
+  a re-generate → double provider spend).
 - The UI renders each asset via a short-lived presigned preview URL (by B2 key)
   — the same path the file manager uses, so it works with or without
   `B2_PUBLIC_URL_BASE`.
@@ -64,7 +70,10 @@ and its outputs also appear in the B2-backed file manager.
   fetch shows a retry, never the locked card (a transient blip must not lock a
   paying user out).
 - Over the daily quota → `429` before the provider is called (no wasted credits).
-- Provider failure / no asset → job persisted as `failed`, endpoint `502`.
+- Provider failure / no asset → job persisted as `failed`, endpoint `502`. The
+  response and the stored `job.error` (readable via `GET /generation/jobs`) carry
+  a **generic** message; raw provider/SDK text — which can embed API keys or
+  signed URLs — is logged server-side only, never surfaced.
 - Private bucket (no public URL base) → assets still render (presigned preview).
 
 ## UX States (if applicable)
@@ -79,7 +88,9 @@ and its outputs also appear in the B2-backed file manager.
   `apps/web/e2e/generate.spec.ts`.
 - Required cases: 402 (Free), 503 (no key), happy path persists
   job+files+usage, failed-run → 502, list jobs, genblaze-only-in-repo,
-  no-network SDK signature guard.
+  no-network SDK signature guard, finalize-write failure → job marked failed
+  (not stranded `running`), secondary-write failure → job stays `succeeded`
+  (no double-spend), and provider error text never leaked to the client/DB.
 - Quick verify command: `pnpm test:api && pnpm check:structure`
 - Full verify command: `pnpm lint && pnpm build && pnpm test:api && pnpm test:e2e`
   (the live e2e generation test needs `NVIDIA_API_KEY` + Stripe/Supabase config;

--- a/services/api/app/service/generation.py
+++ b/services/api/app/service/generation.py
@@ -42,6 +42,24 @@ class GenerationQuotaError(RuntimeError):
     """Raised when a user exceeds the per-day generation cap. Mapped to 429."""
 
 
+# Generic, user-safe failure message. Raw provider/SDK error text can embed API
+# keys or signed URLs, so it is logged server-side (logger.exception) but never
+# returned to the client or written to the stored job.error (which the user can
+# read back via GET /generation/jobs).
+_GENERIC_FAILURE = "Image generation failed. Please try again."
+
+
+async def _safe_mark_failed(job_id: str, error: str) -> None:
+    """Best-effort transition a job to failed so it never lingers as 'running'.
+
+    Swallows its own errors: if the persistence layer is unreachable there is
+    nothing more to do here, and the caller is already surfacing a failure."""
+    try:
+        await supabase_generation.complete_job(job_id, status="failed", error=error)
+    except Exception:
+        logger.exception("could not mark job=%s failed", job_id)
+
+
 def is_configured() -> bool:
     """True when both the provider key and the persistence layer are set."""
     return generation_pipeline.is_configured() and supabase_generation.is_configured()
@@ -95,68 +113,93 @@ async def generate(*, user_id: str, prompt: str, seed: int | None = None) -> Gen
             timeout=settings.generation_deadline,
         )
     except TimeoutError:
+        # The deadline value is our own config, not provider text — safe to show.
         msg = f"Generation timed out after {settings.generation_deadline}s"
-        await supabase_generation.complete_job(job_id, status="failed", error=msg)
+        await _safe_mark_failed(job_id, msg)
         logger.warning("generation timed out for job=%s", job_id)
         raise GenerationError(msg) from None
-    except Exception as exc:  # provider/preflight/network failure
-        await supabase_generation.complete_job(job_id, status="failed", error=str(exc))
+    except Exception:  # provider/preflight/network failure
+        # Log the full detail server-side; never surface raw provider/SDK text.
         logger.exception("generation pipeline raised for job=%s", job_id)
-        raise GenerationError(str(exc)) from exc
+        await _safe_mark_failed(job_id, _GENERIC_FAILURE)
+        raise GenerationError(_GENERIC_FAILURE) from None
 
     assets = result["assets"]
     status = "succeeded" if assets and not result["failed"] else "failed"
+    if status == "failed":
+        # result["error"] is the SDK's own error_summary() — log it, don't store it.
+        logger.warning("generation job=%s produced no asset: %s", job_id, result.get("error"))
+    stored_error = None if status == "succeeded" else _GENERIC_FAILURE
 
-    await supabase_generation.complete_job(
-        job_id,
-        status=status,
-        run_id=result["run_id"],
-        manifest_uri=result["manifest_uri"],
-        canonical_hash=result["canonical_hash"],
-        cost_usd=result["cost_usd"],
-        error=result["error"],
-    )
-    await supabase_generation.record_provider_run(
-        {
-            "job_id": job_id,
-            "provider": "nvidia",
-            "model": result["model"],
-            "run_id": result["run_id"],
-            "status": status,
-            "cost_usd": result["cost_usd"],
-            "assets_count": len(assets),
-        }
-    )
+    # The run is already paid for and (on success) written to B2. The
+    # running->terminal transition is the ONLY write that can strand a job as
+    # 'running', so guard it on its own and fail loudly if it can't land.
+    try:
+        await supabase_generation.complete_job(
+            job_id,
+            status=status,
+            run_id=result["run_id"],
+            manifest_uri=result["manifest_uri"],
+            canonical_hash=result["canonical_hash"],
+            cost_usd=result["cost_usd"],
+            error=stored_error,
+        )
+    except Exception:
+        logger.exception("failed to finalize job=%s; marking failed", job_id)
+        await _safe_mark_failed(job_id, _GENERIC_FAILURE)
+        raise GenerationError(_GENERIC_FAILURE) from None
 
-    file_rows = [
-        {
-            "user_id": user_id,
-            "job_id": job_id,
-            "b2_key": a["key"],
-            "url": a["url"],
-            "sha256": a["sha256"],
-            "media_type": a["media_type"],
-            "size_bytes": a["size_bytes"],
-            "width": a["width"],
-            "height": a["height"],
-        }
-        for a in assets
-        if a.get("key")
-    ]
-    await supabase_generation.insert_files(file_rows)
-
-    if status == "succeeded":
-        await supabase_generation.record_usage_event(
+    # Secondary bookkeeping (provider-run, file rows, usage event). A blip here
+    # must NOT flip an already-succeeded job to failed: the asset exists in B2, so
+    # a re-generate would double provider spend. Log and continue — a missing
+    # provider-run/usage row is a lesser, non-user-facing inconsistency.
+    try:
+        await supabase_generation.record_provider_run(
+            {
+                "job_id": job_id,
+                "provider": "nvidia",
+                "model": result["model"],
+                "run_id": result["run_id"],
+                "status": status,
+                "cost_usd": result["cost_usd"],
+                "assets_count": len(assets),
+            }
+        )
+        file_rows = [
             {
                 "user_id": user_id,
                 "job_id": job_id,
-                "kind": "image_generation",
-                "units": len(assets),
-                "cost_usd": result["cost_usd"],
+                "b2_key": a["key"],
+                "url": a["url"],
+                "sha256": a["sha256"],
+                "media_type": a["media_type"],
+                "size_bytes": a["size_bytes"],
+                "width": a["width"],
+                "height": a["height"],
             }
+            for a in assets
+            if a.get("key")
+        ]
+        await supabase_generation.insert_files(file_rows)
+        if status == "succeeded":
+            await supabase_generation.record_usage_event(
+                {
+                    "user_id": user_id,
+                    "job_id": job_id,
+                    "kind": "image_generation",
+                    "units": len(assets),
+                    "cost_usd": result["cost_usd"],
+                }
+            )
+    except Exception:
+        logger.exception(
+            "secondary persistence failed for job=%s (job left status=%s)", job_id, status
         )
-    else:
-        raise GenerationError(result["error"] or "Generation produced no image")
+
+    # A no-asset run is a failure from the user's perspective; raise AFTER the
+    # terminal status is durably recorded so the job never lingers as 'running'.
+    if status == "failed":
+        raise GenerationError(_GENERIC_FAILURE)
 
     return GenerationJob(
         id=job_id,

--- a/services/api/tests/test_generation.py
+++ b/services/api/tests/test_generation.py
@@ -233,6 +233,111 @@ async def test_generate_502_when_pipeline_raises(client, monkeypatch, fake_store
     assert fake_store.jobs["job-1"]["status"] == "failed"
 
 
+# --- post-success persistence: never strand a job, never leak errors -------
+
+
+@pytest.mark.asyncio
+async def test_generate_marks_failed_when_finalize_write_raises(
+    client, monkeypatch, fake_store
+):
+    """G1: if the running->succeeded transition (complete_job) fails after a paid,
+    B2-written run, the job must not linger as 'running' — it is best-effort marked
+    failed and the caller gets a clean 502, not a 500 with a stuck job."""
+    _auth_as(monkeypatch, tier="pro")
+    monkeypatch.setattr(generation_pipeline, "is_configured", lambda: True)
+    monkeypatch.setattr(generation_pipeline, "generate_image", lambda **kw: _fake_result())
+
+    async def complete_job(job_id, **patch):
+        # The success transition blips; the best-effort failed-write still lands.
+        if patch.get("status") == "succeeded":
+            raise RuntimeError("postgrest 503 finalizing job")
+        fake_store.jobs.setdefault(job_id, {}).update(patch)
+
+    monkeypatch.setattr(supabase_generation, "complete_job", complete_job)
+
+    resp = await client.post(
+        "/generation/generate",
+        headers={"Authorization": "Bearer x"},
+        json={"prompt": "a red bicycle"},
+    )
+    assert resp.status_code == 502
+    assert fake_store.jobs["job-1"]["status"] == "failed", "job stranded as running"
+
+
+@pytest.mark.asyncio
+async def test_generate_stays_succeeded_when_secondary_write_fails(
+    client, monkeypatch, fake_store
+):
+    """G1: a blip in a SECONDARY bookkeeping write (usage event) after the job is
+    already succeeded and the asset is in B2 must NOT flip the job to failed — that
+    would tell the user it failed and prompt a re-generate → double provider spend.
+    The job stays succeeded, the asset is returned, the error is only logged."""
+    _auth_as(monkeypatch, tier="pro")
+    monkeypatch.setattr(generation_pipeline, "is_configured", lambda: True)
+    monkeypatch.setattr(generation_pipeline, "generate_image", lambda **kw: _fake_result())
+
+    async def record_usage_event(row):
+        raise RuntimeError("postgrest 503 recording usage")
+
+    monkeypatch.setattr(supabase_generation, "record_usage_event", record_usage_event)
+
+    resp = await client.post(
+        "/generation/generate",
+        headers={"Authorization": "Bearer x"},
+        json={"prompt": "a red bicycle"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "succeeded"
+    assert len(resp.json()["assets"]) == 1
+    assert fake_store.jobs["job-1"]["status"] == "succeeded"
+    assert fake_store.usage_events == [], "usage write should have failed"
+
+
+@pytest.mark.asyncio
+async def test_generate_does_not_leak_provider_error_text(client, monkeypatch, fake_store):
+    """G2: raw provider/SDK exception text (which can embed keys or signed URLs)
+    must never reach the 502 body or the stored job.error (readable via
+    GET /generation/jobs). It is logged server-side only."""
+    _auth_as(monkeypatch, tier="pro")
+    monkeypatch.setattr(generation_pipeline, "is_configured", lambda: True)
+    secret = "nvcf_key_sk-SECRET-abc123 at https://internal.example/v1?token=leak"
+
+    def boom(**kw):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(generation_pipeline, "generate_image", boom)
+    resp = await client.post(
+        "/generation/generate",
+        headers={"Authorization": "Bearer x"},
+        json={"prompt": "x"},
+    )
+    assert resp.status_code == 502
+    assert "SECRET" not in resp.text and "token=leak" not in resp.text
+    stored_error = fake_store.jobs["job-1"].get("error") or ""
+    assert "SECRET" not in stored_error and "token=leak" not in stored_error
+
+
+@pytest.mark.asyncio
+async def test_generate_no_asset_error_is_generic(client, monkeypatch, fake_store):
+    """G2: the provider's own error_summary() on a no-asset run is SDK-originated
+    and must not be surfaced verbatim either — the stored/returned error is generic."""
+    _auth_as(monkeypatch, tier="pro")
+    monkeypatch.setattr(generation_pipeline, "is_configured", lambda: True)
+    monkeypatch.setattr(
+        generation_pipeline,
+        "generate_image",
+        lambda **kw: _fake_result(assets=[], failed=1, error="raw sdk detail token=leak"),
+    )
+    resp = await client.post(
+        "/generation/generate",
+        headers={"Authorization": "Bearer x"},
+        json={"prompt": "x"},
+    )
+    assert resp.status_code == 502
+    assert "token=leak" not in resp.text
+    assert "token=leak" not in (fake_store.jobs["job-1"].get("error") or "")
+
+
 # --- route: per-user daily quota -------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Part of an iterative production-readiness pass. Fixes two defects on the AI generation path — both on code paths the existing tests didn't exercise.

### Problems
- **Stranded jobs + orphaned files (High):** the four post-success Supabase writes (`complete_job`, `record_provider_run`, `insert_files`, `record_usage_event`) were unguarded. A PostgREST blip *after* a successful, already-paid, already-B2-written run left the job stuck `running` forever, the generated objects orphaned/unmetered, and returned a generic 500.
- **Provider error-text leak (Medium):** raw `str(exc)` / SDK `error_summary()` flowed into the `502` body **and** the stored `generation_jobs.error` (readable by the user via `GET /generation/jobs`) — a path for API keys or signed URLs in SDK messages to leak.

### Fixes
- The running→terminal transition (`complete_job`) is now guarded on its own: if it fails, the job is best-effort marked `failed` and the caller gets a clean `502` — **a job never lingers as `running`**.
- The **secondary** bookkeeping writes log-and-continue on failure and **never flip an already-`succeeded` job to `failed`** (that would tell the user it failed → re-generate → double provider spend). The intentional no-asset `raise` stays outside the catch, after the status is durably recorded.
- The `502` body and stored `job.error` carry only a **generic** message; full provider detail is logged server-side.

### Tests
`services/api/tests/test_generation.py` (+4): finalize-write failure → job marked `failed` (not stranded); secondary-write failure → job stays `succeeded`, asset returned, no double-spend; provider secret text absent from both response and stored error; no-asset error is generic. **14 generation tests pass**; full backend gate green (213 pytest + ruff + structure, file 271 lines < 300).

### Deferred (already logged to tech-debt tracker in #11)
Abandoned genblaze worker-thread pool exhaustion under a hanging endpoint (needs fast-fail/watchdog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)