### PR TITLE
fix(auth): reject expired tokens on a warm identity-cache hit

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -25,11 +25,15 @@ Security principles and implementation for the ai-saas-starter-kit.
   memory). This drops one of the two per-request Supabase round-trips on a warm hit. The
   role/authorization decision (`/rest/v1/profiles`) is **never cached** — it is fetched
   live on every request, so a demoted admin loses access immediately (no
-  privilege-escalation window). Tradeoff: what the cache skips is the identity/liveness
-  check, so a token is honored for up to the TTL past its **expiry or revocation** (not
-  just rotation) — bounded and low-risk here because Supabase access tokens are already
-  bearer-valid until their own ~1h `exp` regardless of logout, and **privilege escalation
-  is impossible** (a stale admin token's live role fetch fails and downgrades to `user`).
+  privilege-escalation window). Because that live call carries the same bearer token,
+  it also re-checks liveness: an **expired token 401/403s there even on a warm cache
+  hit**, and the handler then evicts the cached identity and rejects the request (`401`)
+  rather than defaulting to role `user` — so the cache does **not** extend a token's life
+  past its own `exp`. A transient PostgREST `5xx` (as opposed to a `401/403`) is treated
+  as an unknown role and fails safe to `user` **without** evicting or logging the caller
+  out, so a backend blip can't mass-sign-out valid users. The residual staleness is
+  therefore limited to identity fields (e.g. email) for up to the TTL, which is itself
+  clamped to a ceiling (300s) regardless of a misconfigured `AUTH_CACHE_TTL_SECONDS`.
   Set `AUTH_CACHE_TTL_SECONDS=0` to disable the cache and revalidate identity on every
   request.
 - **Row Level Security** is enabled on `profiles` and `roles`: a user reads/updates only

--- a/services/api/app/repo/supabase_auth.py
+++ b/services/api/app/repo/supabase_auth.py
@@ -14,6 +14,13 @@ from app.repo import http_client
 _TIMEOUT = httpx.Timeout(10.0)
 
 
+class TokenRejected(Exception):
+    """Raised when Supabase rejects the bearer token (401/403) on the live role
+    call — distinct from an empty result. On a warm identity-cache hit this is
+    the ONLY signal that the token is expired/revoked, so the caller must reject
+    the request rather than default to a role (see service.user_from_token)."""
+
+
 async def fetch_user(access_token: str) -> dict | None:
     """Return the Supabase user for a bearer token, or None if it is invalid."""
     resp = await http_client.get_client().get(
@@ -41,7 +48,15 @@ async def fetch_profile_role(access_token: str, user_id: str) -> str | None:
         },
         timeout=_TIMEOUT,
     )
+    if resp.status_code in (httpx.codes.UNAUTHORIZED, httpx.codes.FORBIDDEN):
+        # Token is invalid/expired/revoked. Surface it distinctly so a warm
+        # identity-cache hit still rejects, rather than collapsing to None (which
+        # would default to role "user" and authenticate an invalid token).
+        raise TokenRejected()
     if resp.status_code != httpx.codes.OK:
+        # A transient 5xx / other non-200 can't confirm the role; degrade to the
+        # default role (fail-safe, least-privilege) rather than logging the user
+        # out — do NOT treat it as a rejected token.
         return None
     rows = resp.json()
     return rows[0]["role"] if rows else None

--- a/services/api/app/service/auth.py
+++ b/services/api/app/service/auth.py
@@ -22,10 +22,22 @@ from app.types.auth import AuthUser
 _IDENTITY_CACHE_MAX = 10_000  # cap distinct cached tokens (bounds memory)
 _identity_cache: dict[str, tuple[float, tuple[str, str | None]]] = {}
 
+# Upper bound on the effective identity-cache TTL, regardless of the configured
+# AUTH_CACHE_TTL_SECONDS. Token *validity* is enforced live on every request (an
+# expired/revoked token is rejected by the 401/403 eviction below), so this only
+# bounds how long a since-changed identity (e.g. a new email) is served — a
+# misconfigured large TTL can't stretch that to hours.
+_AUTH_CACHE_TTL_CEILING = 300.0
+
 
 def _reset_cache() -> None:
     """Drop all cached identities (test hook)."""
     _identity_cache.clear()
+
+
+def _effective_ttl() -> float:
+    """The configured identity-cache TTL, clamped to a safe ceiling."""
+    return min(settings.auth_cache_ttl_seconds, _AUTH_CACHE_TTL_CEILING)
 
 
 def _token_key(access_token: str) -> str:
@@ -62,7 +74,7 @@ async def user_from_token(access_token: str) -> AuthUser | None:
     authorization decision is never stale. Returns None when the token is
     missing/invalid so callers can raise 401.
     """
-    ttl = settings.auth_cache_ttl_seconds
+    ttl = _effective_ttl()
     key = _token_key(access_token) if ttl > 0 else None
 
     identity = _cached_identity(key) if key is not None else None
@@ -76,5 +88,14 @@ async def user_from_token(access_token: str) -> AuthUser | None:
 
     user_id, email = identity
     # Role/authorization is fetched live on EVERY request — see module docstring.
-    role = await supabase_auth.fetch_profile_role(access_token, user_id) or "user"
+    # A warm cache hit skips fetch_user (the signature/expiry check), so this live
+    # call is also where an expired/revoked token is caught: the repo raises
+    # TokenRejected on a 401/403, and we evict the cached identity and reject the
+    # request so a stale token can't keep authenticating within the TTL.
+    try:
+        role = await supabase_auth.fetch_profile_role(access_token, user_id) or "user"
+    except supabase_auth.TokenRejected:
+        if key is not None:
+            _identity_cache.pop(key, None)
+        return None
     return AuthUser(id=user_id, email=email, role=role)

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -163,6 +163,113 @@ async def test_ttl_zero_disables_cache(auth_service, monkeypatch):
     assert auth_service._identity_cache == {}  # nothing stored
 
 
+@pytest.mark.asyncio
+async def test_revoked_token_on_warm_cache_is_rejected(auth_service, monkeypatch):
+    """A1: on a warm identity-cache hit the token isn't re-validated by fetch_user,
+    so the live role call is the only place an expired/revoked token surfaces. A
+    401/403 there (TokenRejected) must REJECT the request (not default to role
+    'user') and evict the cached identity so the stale token can't re-authorize."""
+    from app.repo import supabase_auth
+
+    monkeypatch.setattr(settings, "auth_cache_ttl_seconds", 30)
+    state = {"reject": False, "user_calls": 0}
+
+    async def fake_fetch_user(_token):
+        state["user_calls"] += 1
+        return {"id": "u-1", "email": "a@b.co"}
+
+    async def fake_fetch_profile_role(_token, _uid):
+        if state["reject"]:
+            raise supabase_auth.TokenRejected()
+        return "user"
+
+    monkeypatch.setattr(supabase_auth, "fetch_user", fake_fetch_user)
+    monkeypatch.setattr(supabase_auth, "fetch_profile_role", fake_fetch_profile_role)
+
+    # 1. Warm the cache with a valid request.
+    assert (await auth_service.user_from_token("tok")).id == "u-1"
+    assert state["user_calls"] == 1
+
+    # 2. Token now revoked/expired → live role call 401s → reject + evict.
+    state["reject"] = True
+    assert await auth_service.user_from_token("tok") is None
+    assert auth_service._identity_cache == {}, "cached identity not evicted on reject"
+
+    # 3. After eviction the next attempt goes cold (re-validates via fetch_user).
+    state["reject"] = False
+    assert (await auth_service.user_from_token("tok")).id == "u-1"
+    assert state["user_calls"] == 2
+
+
+@pytest.mark.asyncio
+async def test_transient_role_fetch_failure_does_not_log_out(auth_service, monkeypatch):
+    """A transient 5xx on the role call (repo returns None, NOT TokenRejected)
+    must degrade to the default role — never evict the identity or 401 the user.
+    This is the regression guard against a PostgREST blip mass-logging users out."""
+    monkeypatch.setattr(settings, "auth_cache_ttl_seconds", 30)
+    # role=None models a 5xx/empty result (the repo maps both to None).
+    counts = _counting_repo_stubs(monkeypatch, user={"id": "u-1", "email": None}, role=None)
+
+    result = await auth_service.user_from_token("tok")
+    assert result == AuthUser(id="u-1", email=None, role="user")
+    assert counts["role"] == 1
+    # Identity stays cached — a transient failure is not a rejection.
+    assert auth_service._identity_cache != {}
+
+
+def test_effective_ttl_is_clamped_to_ceiling(auth_service, monkeypatch):
+    """A2: a misconfigured large AUTH_CACHE_TTL_SECONDS is capped so identity
+    staleness stays bounded (token validity is enforced live regardless)."""
+    monkeypatch.setattr(settings, "auth_cache_ttl_seconds", 100_000)
+    assert auth_service._effective_ttl() == auth_service._AUTH_CACHE_TTL_CEILING
+    monkeypatch.setattr(settings, "auth_cache_ttl_seconds", 30)
+    assert auth_service._effective_ttl() == 30
+    monkeypatch.setattr(settings, "auth_cache_ttl_seconds", 0)
+    assert auth_service._effective_ttl() == 0  # 0 still disables the cache
+
+
+@pytest.mark.asyncio
+async def test_fetch_profile_role_maps_status_codes(monkeypatch):
+    """The load-bearing 401/403-vs-5xx split the cache-eviction fix hinges on,
+    tested against real HTTP responses (not stubbed at the service boundary):
+    a rejected token raises TokenRejected; a transient 5xx (or an empty result)
+    returns None so the caller degrades to the default role rather than logging
+    the user out."""
+    import httpx
+
+    from app.repo import http_client, supabase_auth
+
+    monkeypatch.setattr(supabase_auth.settings, "supabase_url", "https://db.example")
+    monkeypatch.setattr(supabase_auth.settings, "supabase_anon_key", "anon")
+
+    def use_response(status: int, body) -> httpx.AsyncClient:
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _req: httpx.Response(status, json=body))
+        )
+        monkeypatch.setattr(http_client, "get_client", lambda: client)
+        return client
+
+    async def role_for(status: int, body):
+        client = use_response(status, body)
+        try:
+            return await supabase_auth.fetch_profile_role("tok", "u-1")
+        finally:
+            await client.aclose()
+
+    assert await role_for(200, [{"role": "admin"}]) == "admin"
+    assert await role_for(200, []) is None  # no profile row
+    assert await role_for(500, {}) is None  # transient — degrade, don't reject
+    assert await role_for(503, {}) is None
+
+    for code in (401, 403):
+        client = use_response(code, {})
+        try:
+            with pytest.raises(supabase_auth.TokenRejected):
+                await supabase_auth.fetch_profile_role("tok", "u-1")
+        finally:
+            await client.aclose()
+
+
 def test_cache_is_bounded_and_purges_expired_first(auth_service, monkeypatch):
     """The store caps the cache: expired entries are purged first, and if still
     at capacity the soonest-to-expire live entry is evicted — so token churn


### PR DESCRIPTION
## Summary

Part of an iterative production-readiness pass. Closes an auth-cache hole where an **invalid token could authenticate as a valid `user`**.

> **Merge after** #13 (frontend resilience). This PR converts a currently-silent expired-token case into a clean `401`; #13's redirect-loop guard is what handles that `401` without looping when a stale Supabase cookie is still present.

### Problem (Medium)
Identity is cached for a short TTL to save a Supabase round-trip; the role is fetched live every request. But on a warm cache hit `fetch_user` (the signature/expiry check) is skipped, and `fetch_profile_role` collapsed **any** non-200 — including a `401` from an expired/revoked token — to `None`, which `user_from_token` then defaulted to role `"user"`. So a token Supabase would reject authenticated as a valid user for up to the TTL.

### Fix
- `repo.fetch_profile_role` raises `TokenRejected` on `401/403` (invalid token), distinct from an empty profile row. A transient `5xx` still returns `None` so a PostgREST blip **degrades to the default role without evicting or logging valid users out** (no mass-logout).
- `user_from_token` catches `TokenRejected`, **evicts the cached identity**, and returns `None` (→ `401`) — a stale token can no longer keep authenticating within the TTL, and the cache no longer extends a token past its own `exp`. Admin authorization was already safe (a 401 role fetch → `user` → 403); this closes the non-admin read path.
- Clamp the effective cache TTL to a **300s ceiling** regardless of a misconfigured `AUTH_CACHE_TTL_SECONDS` (identity staleness only; token validity is enforced live).

### Tests
`services/api/tests/test_auth.py` (+4): expired-token-on-warm-hit → rejected + evicted + cold re-validate; **transient 5xx → NOT logged out** (regression guard); TTL clamp; and a **repo-level status-code test** (`401/403 → TokenRejected`, `5xx/empty → None`, `200 → role`) pinning the exact split the fix hinges on. **15 auth tests pass**; full backend gate green (212 pytest + ruff + structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)