### PR TITLE
fix(observability): log tracebacks for 500s; safe docs default; reconcile CI doc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,9 +59,10 @@ STRIPE_PRICE_TEAM=
 # origin in production (e.g. https://api-production-xxx.up.railway.app).
 # NEXT_PUBLIC_API_URL=http://localhost:8000
 
-# Interactive API docs (/docs, /redoc, /openapi.json). OFF by default so
-# production doesn't expose the full API surface. Turn on for local exploration.
-ENABLE_DOCS=true
+# Interactive API docs (/docs, /redoc, /openapi.json). OFF by default so a
+# verbatim copy of this file into production doesn't expose the full API surface.
+# Uncomment for local exploration.
+# ENABLE_DOCS=true
 
 # --- Production overrides (unset locally; needed once deployed) ---
 # CORS allowlist for the API (comma-separated). Defaults to localhost — add your

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,10 +89,15 @@ pnpm test:web          # frontend unit tests (vitest)
 pnpm lint:api          # backend lint (ruff)
 pnpm test:api          # backend tests (pytest)
 pnpm check:structure   # structural boundary tests
-pnpm test:e2e          # Playwright e2e tests
+pnpm test:e2e          # Playwright e2e tests (local / pre-release only — see below)
 ```
 
-CI (`.github/workflows/ci.yml`) runs these gates on every PR and push to `main`.
+CI (`.github/workflows/ci.yml`) runs the lint, type-check/build, unit, and
+structural gates on every PR and push to `main`: `lint`, `build`, `test:web`,
+`lint:api`, `test:api`, `check:structure`. **`test:e2e` is NOT in CI** — the
+Playwright journeys need the full stack (Supabase + API + Stripe CLI + mailpit),
+which isn't wired into CI yet; run it locally as a pre-release gate (see
+`docs/exec-plans/tech-debt-tracker.md`).
 
 ## 7. Agent Workflow
 

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -146,7 +146,11 @@ class JSONFormatter(logging.Formatter):
         if hasattr(record, "request_id"):
             log_entry["request_id"] = record.request_id
         if record.exc_info and record.exc_info[1]:
+            # Keep the message for quick scanning, but also emit the full
+            # traceback — this is the single sink for unhandled 500s, and a bare
+            # message ("B2 exploded") gives no file/line to debug from.
             log_entry["exception"] = str(record.exc_info[1])
+            log_entry["traceback"] = self.formatException(record.exc_info)
         return json.dumps(log_entry)
 
 

--- a/services/api/tests/test_error_handling.py
+++ b/services/api/tests/test_error_handling.py
@@ -1,10 +1,45 @@
 """Tests for error handling across the API."""
 
+import json
+import logging
+
 import pytest
 
 from app.service import files as files_service
 
 from .conftest import TEST_USER_ID
+
+
+def test_json_formatter_includes_traceback():
+    """The structured-log formatter (the single sink for unhandled 500s) must emit
+    the full traceback, not just the exception message — otherwise a prod 500 logs
+    'B2 exploded' with no file/line to debug from."""
+    import main
+
+    try:
+        raise ValueError("boom detail")
+    except ValueError:
+        import sys
+
+        record = logging.LogRecord(
+            "api", logging.ERROR, __file__, 1, "request failed", None, sys.exc_info()
+        )
+
+    entry = json.loads(main.JSONFormatter().format(record))
+    assert entry["exception"] == "boom detail"  # message preserved for scanning
+    assert "traceback" in entry
+    assert "ValueError: boom detail" in entry["traceback"]
+    assert "test_json_formatter_includes_traceback" in entry["traceback"]  # has frames
+
+
+def test_json_formatter_omits_traceback_without_exc_info():
+    """A normal log line carries no traceback field."""
+    import main
+
+    record = logging.LogRecord("api", logging.INFO, __file__, 1, "ok", None, None)
+    entry = json.loads(main.JSONFormatter().format(record))
+    assert "traceback" not in entry
+    assert "exception" not in entry
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Final PR of an iterative production-readiness pass — three small, low-risk infra/observability/doc fixes.

### Fixes
- **500s logged blind (Medium):** the structured-log `JSONFormatter` (the single sink for unhandled errors) recorded only the exception *message*, never the traceback — a prod 500 logged `"exception": "B2 exploded"` with no file/line. It now also emits the full `traceback`. **Log-only** — the client still receives the static `{"detail":"Internal server error"}`.
- **`.env.example` unsafe docs default (Low):** shipped `ENABLE_DOCS=true`, contradicting the safe code default (`False`) and the Railway "leave unset in prod" note — a verbatim copy into a deploy would expose `/docs`, `/redoc`, `/openapi.json`. Now commented out (uncomment for local exploration).
- **CI doc overclaim:** `AGENTS.md` §6 implied CI runs `test:e2e`; it doesn't (Playwright needs the full stack). Clarified that e2e is a local/pre-release gate, matching the tech-debt tracker.

### Tests
`services/api/tests/test_error_handling.py` (+2): formatter emits the traceback with `exc_info`, omits it without. **211 backend tests pass**; ruff + structure green.

### Deferred by design (not addressed here)
`/health` returns `200` with `{"status":"degraded"}` when B2 is unreachable — defensible anti-flap behavior; a strict readiness endpoint is a larger, deliberate choice left to the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)