### PR TITLE
fix(deps): pin brace-expansion@5 >=5.0.8 (CVE-2026-14257)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "body-parser@2": ">=2.3.0 <3",
       "brace-expansion@1": ">=1.1.16 <2",
       "brace-expansion@2": ">=2.1.2 <3",
+      "brace-expansion@5": ">=5.0.8 <6",
       "express-rate-limit@8": ">=8.2.2 <9",
       "fast-uri@3": ">=3.1.4 <4",
       "flatted@3": ">=3.4.2 <4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   body-parser@2: '>=2.3.0 <3'
   brace-expansion@1: '>=1.1.16 <2'
   brace-expansion@2: '>=2.1.2 <3'
+  brace-expansion@5: '>=5.0.8 <6'
   express-rate-limit@8: '>=8.2.2 <9'
   fast-uri@3: '>=3.1.4 <4'
   flatted@3: '>=3.4.2 <4'


### PR DESCRIPTION
## Summary

Closes the one remaining Dependabot alert — **#134, `brace-expansion` ≤ 5.0.7, HIGH (CVE-2026-14257, DoS via unbounded brace expansion → OOM)**, filed moments after the npm advisory sweep (#16) merged.

## Context

The lockfile already resolved the `brace-expansion` 5.x line to **5.0.8 — the patched version** — so nothing vulnerable is actually installed. But #16 pinned only `brace-expansion@1` and `@2`; the `@5` instance was left floating and could regress below the fix on a future install. This adds `brace-expansion@5: ">=5.0.8 <6"` to complete the per-major coverage and lock it.

## Verification

- Installed `brace-expansion` versions after the pin: **1.1.16, 2.1.2, 5.0.8** — all at/above their respective fixes; no ≤5.0.7 present.
- Installed version is unchanged (5.0.8 was already resolved), so this is a lock, not a version bump.
- Web lint clean, 72 unit tests pass, build + TypeScript pass.

Dependabot closes #134 once this lands on `main` and it re-scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)